### PR TITLE
tests: add custom parametrize and terminals tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -26,3 +26,4 @@ flake8-ignore =
   *.py E121 E123 E126 E128 E501 F401
   *.py FI12 FI14 FI15 FI16 FI17 FI50 FI51 FI53
   docs/conf.py ALL
+norecursedirs=tests/helpers

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ tests_require = [
     'pytest-cov>=1.8.0',
     'pytest-flake8>=0.8.1',
     'pytest>=2.8.0',
+    'six>=1.10.0'
 ]
 
 extras_require = {
@@ -85,6 +86,8 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3'
+        'Programming Language :: Python :: 3.6'
         'Development Status :: 2 - Pre-Alpha',
     ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,3 +23,10 @@
 """Pytest configuration."""
 
 from __future__ import absolute_import, print_function
+
+import sys
+import os
+
+# Use the helpers folder to store test helpers.
+# See: http://stackoverflow.com/a/33515264/374865
+sys.path.append(os.path.join(os.path.dirname(__file__), 'helpers'))

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import
+
+import pytest
+from collections import OrderedDict
+from six import iteritems, itervalues, next, viewitems, viewkeys, viewvalues, iterkeys
+
+
+def parametrize(test_configurations):
+    """Custom parametrize method that accepts a more readable test conf. format.
+
+    It accepts a dictionary whose keys are the test names (ids equivalent) and
+    the value of each key is a dictionary of test configuration, in the form of
+    { test_parameter1: x, test_parameter2: y}
+
+    Example:
+        {
+            'Unicode tokens': {'query_str': 'γ-radiation', 'unrecognised_text': ''},
+            'Simple token: {'query_str': 'foo', 'unrecognized_text': ''}
+        }
+    """
+    if not test_configurations:
+        __tracebackhide__ = True
+        pytest.fail('In parametrize test configurations parameter cannot be empty.')
+
+    if not isinstance(test_configurations, dict):
+        __tracebackhide__ = True
+        pytest.fail('In parametrize test configurations parameter must be a dictionary.')
+
+    ordered_tests_config = OrderedDict(sorted(viewitems(test_configurations)))
+
+    for test_name, test_configuration in iteritems(ordered_tests_config):
+        ordered_tests_config[test_name] = OrderedDict(sorted(viewitems(test_configuration)))
+
+    # Extract arg_names from a test configuration
+    arg_names = list(iterkeys(next(itervalues(ordered_tests_config))))
+
+    # Generate list of arg_values
+    arg_values = [ordered_tests_config[test_config].values() for test_config in ordered_tests_config]
+
+    # Generate ids list
+    ids = list(iterkeys(ordered_tests_config))
+    return pytest.mark.parametrize(argnames=arg_names, argvalues=arg_values, ids=ids)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import print_function, unicode_literals
+
+
+from inspire_query_parser.parser import SimpleValue, SimpleValueUnit
+from inspire_query_parser.stateful_pypeg_parser import StatefulParser
+from test_utils import parametrize
+
+
+# Test parse terminal token
+def test_that_parse_terminal_token_does_accept_keywords_if_parsing_parenthesized_terminal_flag_is_on():
+    query_str = 'and'
+
+    parser = StatefulParser()
+    parser.parsing_parenthesized_terminal = True
+
+    returned_unrecognised_text, returned_result = SimpleValueUnit.parse_terminal_token(parser, query_str)
+    assert returned_unrecognised_text == ''
+    assert returned_result == query_str
+
+
+def test_that_parse_terminal_token_does_not_accept_token_followed_by_colon():
+    query_str = 'title:'
+
+    parser = StatefulParser()
+
+    returned_unrecognised_text, returned_result = SimpleValueUnit.parse_terminal_token(parser, query_str)
+    assert isinstance(returned_result, SyntaxError)
+    assert returned_unrecognised_text == query_str
+
+
+def test_that_parse_terminal_token_does_not_accept_non_shortened_inspire_keywords():
+    query_str = "exact-author"
+
+    parser = StatefulParser()
+
+    returned_unrecognised_text, returned_result = SimpleValueUnit.parse_terminal_token(parser, query_str)
+    assert isinstance(returned_result, SyntaxError)
+    assert returned_unrecognised_text == query_str
+
+
+# Testing SimpleValueUnit (terminals recognition) cases (no parenthesized SimpleValue).
+@parametrize(
+    {
+        # Date specifiers
+        'Date specifiers arithmetic: today': {
+            'query_str': 'today - 2',
+            'unrecognized_text': '',
+            'result': SimpleValueUnit('today - 2')
+        },
+        'Date specifiers arithmetic: yesterday': {
+            'query_str': 'yesterday  - 365',
+            'unrecognized_text': '',
+            'result': SimpleValueUnit('yesterday  - 365')
+        },
+        'Date specifiers arithmetic: this month': {
+            'query_str': 'this month -  1',
+            'unrecognized_text': '',
+            'result': SimpleValueUnit('this month -  1')
+        },
+        'Date specifiers arithmetic: last month': {
+            'query_str': 'last month-1',
+            'unrecognized_text': '',
+            'result': SimpleValueUnit('last month-1')
+        },
+        'Date specifier w/o arithmetic (followed by a query)': {
+            'query_str': 'today -  a',
+            'unrecognized_text': ' -  a',
+            'result': SimpleValueUnit('today')
+        },
+
+        # Only arxiv identifier should be accepted as a token that contains ":".
+        'Canonical arxiv identifier': {
+            'query_str': 'arxiv:1706.04080',
+            'unrecognized_text': '',
+            'result': SimpleValueUnit('arxiv:1706.04080')
+        },
+        'Arxiv identifier with semantically erroneous value (semantic error)': {
+            'query_str': 'arxiv:foo',
+            'unrecognized_text': '',
+            'result': SimpleValueUnit('arxiv:foo')
+        },
+        'Non arxiv-related terminal with colon': {
+            'query_str': 'not_arxiv:foo',
+            'unrecognized_text': 'not_arxiv:foo',
+            'result': SyntaxError(u'expecting match on SimpleValueUnit',)
+        },
+
+        # Basic tokens
+        'Simple token': {
+            'query_str': 'foo',
+            'unrecognized_text': '',
+            'result': SimpleValueUnit('foo')
+        },
+        'Unicode token': {
+            'query_str': 'γ-radiation',
+            'unrecognized_text': '',
+            'result': SimpleValueUnit('γ-radiation')
+        },
+        # Tokens separated by whitespace, don't get recognized by SimpleValueUnit.
+        'Many tokens (whitespace separated)': {
+            'query_str': 'foo bar',
+            'unrecognized_text': ' bar',
+            'result': SimpleValueUnit('foo')
+        },
+    }
+)
+def test_simple_value_unit_accepted_tokens(query_str, unrecognized_text, result):
+    parser = StatefulParser()
+
+    returned_unrecognised_text, returned_result = SimpleValueUnit.parse(parser, query_str, None)
+    if type(result) != SyntaxError:
+        assert returned_unrecognised_text == unrecognized_text
+        assert returned_result == result
+    else:
+        assert returned_unrecognised_text == unrecognized_text
+        assert isinstance(returned_result, SyntaxError) and result.msg == result.msg
+
+
+@parametrize(
+    {
+        'Multiple whitespace-separated tokens': {
+            'query_str': 'foo bar',
+            'unrecognized_text': '',
+            'result': SimpleValue('foo bar')
+        },
+        'Plaintext with parentheses': {
+            'query_str': 'foo(a)',
+            'unrecognized_text': '',
+            'result': SimpleValue('foo(a)')
+        },
+        'Plaintext with keywords (or keyword symbols +/-/|) in parentheses': {
+            'query_str': '(and)',
+            'unrecognized_text': '',
+            'result': SimpleValue('(and)')
+        }
+    }
+)
+def test_simple_value_accepted_tokens(query_str, unrecognized_text, result):
+    parser = StatefulParser()
+
+    returned_unrecognised_text, returned_result = SimpleValue.parse(parser, query_str, None)
+    if type(result) != SyntaxError:
+        assert returned_unrecognised_text == unrecognized_text
+        assert returned_result == result
+    else:
+        assert returned_unrecognised_text == unrecognized_text
+        assert isinstance(returned_result, SyntaxError) and result.msg == result.msg


### PR DESCRIPTION
* Add custom parametrize in tests/helpers. Use sys.path append hack for
  using it at tests.
* Add tests for plaintext parsing:
    * SimpleValueUnit parse and parse_terminal_token methods
    * SimpleValue parse method
* Refactor parse_terminal_token with clearer variable names and allow
  SimpleValue `__init__` to accept text_type for making it testable.

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>