### PR TITLE
global: refactoring & convert to unicode @ parse

### DIFF
--- a/inspire_query_parser/ast.py
+++ b/inspire_query_parser/ast.py
@@ -23,6 +23,7 @@
 # Abstract Syntax Tree classes
 # I.e. generic syntax tree classes that simply define categories
 # for each of the actual AST nodes.
+from __future__ import unicode_literals
 
 
 class Leaf(object):
@@ -93,14 +94,14 @@ class ListOp(object):
         return visitor.visit(self, [c.accept(visitor) for c in self.children])
 
     def __eq__(self, other):
-        return type(self) == type(other) and self.op == other.op
+        return type(self) == type(other) and self.children == other.children
 
     def __repr__(self):
         return "%s(%s)" % (self.__class__.__name__, repr(self.children))
+
+
 # Concrete Syntax Tree classes
 # I.e. classes that provide the supertypes for the parser nodes.
-
-
 class Keyword(Leaf):
     pass
 

--- a/inspire_query_parser/config.py
+++ b/inspire_query_parser/config.py
@@ -27,6 +27,7 @@ This dictionary has a twofold use.
 Primarily, the parser uses its keys to generate INSPIRE related keywords (i.e. qualifiers) and secondly, provides
 a normalization of the shortened keywords to their full version.
 """
+from __future__ import unicode_literals
 
 INSPIRE_PARSER_KEYWORDS = {
     # Abstract

--- a/inspire_query_parser/parser.py
+++ b/inspire_query_parser/parser.py
@@ -22,10 +22,10 @@
 
 from __future__ import print_function, unicode_literals
 
+import six
 from pypeg2 import (Enum, GrammarValueError, K, Keyword, Literal, attr,
                     contiguous, maybe_some, omit, optional, re, some,
                     whitespace)
-import six
 
 from . import ast
 from .config import INSPIRE_KEYWORDS_SET, INSPIRE_PARSER_KEYWORDS
@@ -76,17 +76,22 @@ class BooleanOperator(Enum):
 
 
 class LeafRule(ast.Leaf):
-    def __init__(self):
-        pass
+    def __init__(self, value=None):
+        if value:
+            super(LeafRule, self).__init__(value)
 
 
 class UnaryRule(ast.UnaryOp):
-    def __init__(self):
-        pass
+    def __init__(self, op=None):
+        if op:
+            super(UnaryRule, self).__init__(op)
 
 
 class BinaryRule(ast.BinaryOp):
-    def __init__(self):
+    def __init__(self, left=None, right=None):
+        if left and right:
+            self.left = left
+            self.right = right
         pass
 
 

--- a/inspire_query_parser/stateful_pypeg_parser.py
+++ b/inspire_query_parser/stateful_pypeg_parser.py
@@ -19,8 +19,7 @@
 # In applying this license, CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
-
-
+import six
 from pypeg2 import Parser
 
 
@@ -56,6 +55,9 @@ def parse(text, thing):
         GrammarTypeError:   if grammar contains an object of unknown type
         GrammarValueError:  if grammar contains an illegal cardinality value
     """
+    if not isinstance(text, six.text_type):
+        text = six.text_type(text.decode('utf-8'))
+
     parser = StatefulParser()
     t, r = parser.parse(text, thing)
     if t:

--- a/inspire_query_parser/utils/format_parse_tree.py
+++ b/inspire_query_parser/utils/format_parse_tree.py
@@ -20,6 +20,8 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
+from __future__ import absolute_import, unicode_literals
+
 import six
 
 from ..ast import BinaryOp, Leaf, ListOp, UnaryOp
@@ -38,7 +40,7 @@ def emit_tree_format(tree, verbose=False):
         str:  tree-like representation of the parse tree
     """
     if verbose:
-        print("Converting: " + str(tree))
+        print("Converting: " + repr(tree))
     ret_str = __recursive_formatter(tree)
     return ret_str
 
@@ -54,32 +56,32 @@ def __emit_symbol_at_level_str(symbol, level, is_last=False):
                 ret_str += " "
         return ret_str + prefix
 
-    return emit_prefix() + str(symbol) + "\n"
+    return emit_prefix() + symbol + "\n"
 
 
 def __recursive_formatter(node, level=-INDENTATION):
     new_level = INDENTATION + level
 
-    if issubclass(type(node), Leaf):
+    if isinstance(node, Leaf):
         value = "" if not repr(node.value) or repr(node.value) == "None" \
-            else node.__class__.__name__ + " {" + node.value.encode('utf-8') + "}"
+            else node.__class__.__name__ + " {" + node.value + "}"
 
         ret_str = __emit_symbol_at_level_str(value, new_level) if value != "" else ""
 
-    elif issubclass(type(node), six.text_type):
+    elif isinstance(node, six.text_type):
         value = "" if not repr(node) or repr(node) == "None" \
-            else node.__class__.__name__ + " {" + node.encode('utf-8') + "}"
+            else "Text {" + node + "}"
 
         ret_str = __emit_symbol_at_level_str(value, new_level) if value != "" else ""
 
     else:
         ret_str = __emit_symbol_at_level_str(node.__class__.__name__, new_level)
-        if issubclass(type(node), UnaryOp):
+        if isinstance(node, UnaryOp):
             ret_str += __recursive_formatter(node.op, new_level)
             if not node.op:
                 ret_str = ""
 
-        elif issubclass(type(node), BinaryOp):
+        elif isinstance(node, BinaryOp):
             try:
                 if node.bool_op:
                     ret_str = __emit_symbol_at_level_str(
@@ -91,7 +93,7 @@ def __recursive_formatter(node, level=-INDENTATION):
             ret_str += __recursive_formatter(node.left, new_level)
             ret_str += __recursive_formatter(node.right, new_level)
 
-        elif issubclass(type(node), ListOp):
+        elif isinstance(node, ListOp):
             try:
                 len(node.children)
                 for c in node.children:
@@ -103,6 +105,6 @@ def __recursive_formatter(node, level=-INDENTATION):
         elif not node:
             return ""
         else:
-            raise TypeError("Unexpected base type: " + str(type(node)))
+            raise TypeError("Unexpected base type: " + repr(type(node)))
 
     return ret_str

--- a/inspire_query_parser/utils/utils.py
+++ b/inspire_query_parser/utils/utils.py
@@ -22,8 +22,6 @@
 
 from __future__ import print_function
 
-import sys
-
 
 class Colors(object):
     HEADER = '\033[95m'

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -22,9 +22,10 @@
 
 from __future__ import absolute_import
 
-import pytest
 from collections import OrderedDict
-from six import iteritems, itervalues, next, viewitems, viewkeys, viewvalues, iterkeys
+
+import pytest
+from six import iteritems, iterkeys, itervalues, next, viewitems
 
 
 def parametrize(test_configurations):

--- a/tests/test_format_parse_tree.py
+++ b/tests/test_format_parse_tree.py
@@ -20,13 +20,20 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-"""Pytest configuration."""
+from __future__ import absolute_import, unicode_literals
 
-from __future__ import absolute_import, print_function
+from inspire_query_parser.parser import (Expression, InvenioKeywordQuery,
+                                         Query, SimpleQuery, SimpleValue,
+                                         Statement, Value)
+from inspire_query_parser.utils.format_parse_tree import emit_tree_format
 
-import os
-import sys
 
-# Use the helpers folder to store test helpers.
-# See: http://stackoverflow.com/a/33515264/374865
-sys.path.append(os.path.join(os.path.dirname(__file__), 'helpers'))
+def test_format_parse_tree_handles_unicode_values():
+    parse_tree = Query([Statement(Expression(SimpleQuery(Value(SimpleValue('γ-radiation')))))])
+    assert emit_tree_format(parse_tree, verbose=True)
+
+
+def test_format_parse_tree_handles_unicode_nodes():
+    parse_tree = Query([Statement(Expression(SimpleQuery(InvenioKeywordQuery('unicode-keyword-φοο',
+                                                                             Value(SimpleValue('γ-radiation'))))))])
+    assert emit_tree_format(parse_tree, verbose=True)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -22,7 +22,6 @@
 
 from __future__ import print_function, unicode_literals
 
-
 from inspire_query_parser.parser import SimpleValue, SimpleValueUnit
 from inspire_query_parser.stateful_pypeg_parser import StatefulParser
 from test_utils import parametrize


### PR DESCRIPTION
* parser: Add convert input to unicode at current entrypoint (parse
  method).
* format_parse_tree: Use unicode literals and assume input is unicode.
* tests: Add test for format_parse_tree module (handling of unicode).
* ast: Bug-fix ast.ListOp.__eq__ implementation checking for op field.
* parser: Add __init__ for LeafRule, UnaryRule and BinaryRule for being
  able to instantiate a parse tree in tests.

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>