### PR TITLE
parser: GE/LE bug-fix in "number{-,+}" recognition

### DIFF
--- a/demo_parser.py
+++ b/demo_parser.py
@@ -89,6 +89,7 @@ if __name__ == '__main__':
     print_query_and_parse_tree(r"author:ellis j title:'boson' reference:M.N.1")
     print_query_and_parse_tree(r"author:ellis j title 'boson' reference:M.N.1")
     print_query_and_parse_tree(r"author ellis title 'boson' not value")
+    print_query_and_parse_tree(r"author ellis - title 'boson'")
 
     # ##### Boolean operators at terminals level ####
     # 1. Boolean operators among simple values
@@ -177,7 +178,6 @@ if __name__ == '__main__':
     print_query_and_parse_tree(r"date >= nov 2000 - author ellis")
     print_query_and_parse_tree(r"date 1978+ + -ac 100+")
     print_query_and_parse_tree(r"date 2010-06+ or foo")
-    print_query_and_parse_tree(r"date 2010-06   + or foo")
     print_query_and_parse_tree(r"date before 2000 and ac < 100")
     print_query_and_parse_tree(r"date before 2000 and ac 100+")
     print_query_and_parse_tree(r"ac 100- and -date <= 2000")

--- a/inspire_query_parser/parser.py
+++ b/inspire_query_parser/parser.py
@@ -459,10 +459,9 @@ class GreaterEqualOp(UnaryRule):
     """
     grammar = [
         (omit(Literal(">=")), attr('op', SimpleValue)),
-        # Accept a number or anything that doesn't contain {whitespace, (, ), :} followed by a "-" which should be
+        # Accept a number or numbers that are separated with (/ or -) followed by a "-" which should be
         # followed by \s or ) or end of input so that you don't accept a value that is 1-e.
-        (attr('op', re.compile(r"\d+")), omit(re.compile(r'\+(?=\s|\)|$)'))),
-        (attr('op', re.compile(r"[^\s():]+(?=([ ]+\+|\+))")), omit(re.compile(r'\+(?=\s|\)|$)'))),
+        (attr('op', re.compile(r"\d+([/-]\d+)*(?=\+)")), omit(re.compile(r'\+(?=\s|\)|$)'))),
     ]
 
 
@@ -481,11 +480,9 @@ class LessEqualOp(UnaryRule):
     """
     grammar = [
         (omit(Literal("<=")), attr('op', SimpleValue)),
-        # Accept a number or anything that doesn't contain {whitespace, (, ), :} followed by a "-" which should be
+        # Accept a number or numbers that are separated with (/ or -) followed by a "-" which should be
         # followed by \s or ) or end of input so that you don't accept a value that is 1-e.
-        (attr('op', re.compile(r"\d+")), omit(re.compile(r'-(?=\s|\)|$)'))),
-        (attr('op', re.compile(r"[^\s():]+(?=( -|-))")), omit(re.compile(r'\+(?=\s|\)|$)'))),
-
+        (attr('op', re.compile(r"\d+([/-]\d+)*(?=-)")), omit(re.compile(r'-(?=\s|\)|$)'))),
     ]
 
 


### PR DESCRIPTION
* Make GreaterEqualOp and LessEqualOp stricter:
    * Make recognition of number(s){-,+} format stricter, i.e. don't accept
      whitespace between number and symbols.
    * Remove rule for accepting everything that isn't a whitespace and
      accept number or numbers separated by (/,-) symbols.
  These changes aim to eliminate ambiguity with (-,+) symbols, among
  boolean queries and GE/LE values.

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>