### PR TITLE
global: add driver implementation (public API)

### DIFF
--- a/inspire_query_parser/__init__.py
+++ b/inspire_query_parser/__init__.py
@@ -23,3 +23,6 @@
 """A PEG-based query parser for INSPIRE"""
 
 from __future__ import absolute_import, print_function
+
+from . import config
+from .parsing_driver import parse_query

--- a/inspire_query_parser/parsing_driver.py
+++ b/inspire_query_parser/parsing_driver.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""This module provides the public API of INSPIRE query parser."""
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+import logging
+
+from inspire_query_parser import ast
+from inspire_query_parser.parser import Query
+from inspire_query_parser.stateful_pypeg_parser import StatefulParser
+from inspire_query_parser.utils.format_parse_tree import emit_tree_format
+from inspire_query_parser.visitors.elastic_search_visitor import \
+    ElasticSearchVisitor
+from inspire_query_parser.visitors.restructuring_visitor import \
+    RestructuringVisitor
+
+logger = logging.getLogger(__name__)
+
+
+def parse_query(query_str):
+    """
+    Drives the whole logic, by parsing, restructuring and finally, generating an ElasticSearch query.
+
+    Args:
+        query_str (six.text_types): the given query to be translated to an ElasticSearch query
+
+    Returns:
+        six.text_types: Return an ElasticSearch query.
+    """
+    def _generate_empty_query_parse_tree():
+        return ast.EmptyQuery(None)
+
+    logger.info('Parsing: "' + query_str + '\".')
+
+    parser = StatefulParser()
+    rst_visitor = RestructuringVisitor()
+    es_visitor = ElasticSearchVisitor()
+
+    try:
+        unrecognized_text, parse_tree = parser.parse(query_str, Query)
+
+        if unrecognized_text:  # Usually, should never happen.
+            msg = 'Parser returned unrecognized text: "' + unrecognized_text + \
+                  '" for query: "' + query_str + '". '
+
+            if query_str == unrecognized_text and parse_tree is None:
+                # Didn't recognize anything.
+                msg += 'Continuing with an empty query.'
+                parse_tree = _generate_empty_query_parse_tree()
+            else:
+                msg += 'Continuing with recognized parse tree.'
+
+            logger.warn(msg)
+
+    except SyntaxError:
+        logger.warn('Parser syntax error with query: "' + query_str + '". Continuing with an empty query.')
+        parse_tree = _generate_empty_query_parse_tree()
+
+    restructured_parse_tree = parse_tree.accept(rst_visitor)
+    logger.debug('Parse tree: \n' + emit_tree_format(restructured_parse_tree))
+
+    es_query = restructured_parse_tree.accept(es_visitor)
+
+    return es_query

--- a/inspire_query_parser/visitors/__init__.py
+++ b/inspire_query_parser/visitors/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.

--- a/inspire_query_parser/visitors/elastic_search_visitor.py
+++ b/inspire_query_parser/visitors/elastic_search_visitor.py
@@ -28,10 +28,11 @@ visitor and converts it to an ElasticSearch query.
 from __future__ import absolute_import, unicode_literals
 
 import logging
+
 import six
 
-from inspire_query_parser.visitors.visitor_impl import Visitor
 from inspire_query_parser import ast
+from inspire_query_parser.visitors.visitor_impl import Visitor
 
 logger = logging.getLogger(__name__)
 

--- a/inspire_query_parser/visitors/restructuring_visitor.py
+++ b/inspire_query_parser/visitors/restructuring_visitor.py
@@ -31,7 +31,6 @@ from __future__ import absolute_import, unicode_literals
 
 import logging
 
-
 from inspire_query_parser import ast
 from inspire_query_parser.ast import (AndOp, ExactMatchValue, Keyword,
                                       KeywordOp, NotOp, OrOp,
@@ -42,7 +41,6 @@ from inspire_query_parser.parser import (And, ComplexValue,
 from inspire_query_parser.utils.visitor_utils import \
     DATE_SPECIFIERS_CONVERSION_HANDLERS
 from inspire_query_parser.visitors.visitor_impl import Visitor
-
 
 logger = logging.getLogger(__name__)
 

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ readme = open('README.rst').read()
 tests_require = [
     'coverage>=4.4',
     'isort>=4.2.2',
+    'mock>=1.3.0',
     'pytest-cache>=1.0',
     'pytest-cov>=1.8.0',
     'pytest-flake8>=0.8.1',

--- a/tests/test_elastic_search_visitor.py
+++ b/tests/test_elastic_search_visitor.py
@@ -28,8 +28,10 @@ import pytest
 from inspire_query_parser import parser
 from inspire_query_parser.stateful_pypeg_parser import StatefulParser
 from inspire_query_parser.utils.format_parse_tree import emit_tree_format
-from inspire_query_parser.visitors.elastic_search_visitor import ElasticSearchVisitor
-from inspire_query_parser.visitors.restructuring_visitor import RestructuringVisitor
+from inspire_query_parser.visitors.elastic_search_visitor import \
+    ElasticSearchVisitor
+from inspire_query_parser.visitors.restructuring_visitor import \
+    RestructuringVisitor
 
 
 def _parse_query(query_str):

--- a/tests/test_parsing_driver.py
+++ b/tests/test_parsing_driver.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, unicode_literals
+
+import mock
+
+from inspire_query_parser.parsing_driver import parse_query
+
+
+def test_driver_with_simple_query():
+    query_str = 'author: ellis'
+    expected_es_query = {
+        "match": {
+            "authors.full_name": "ellis"
+        }
+    }
+
+    es_query = parse_query(query_str)
+
+    assert es_query == expected_es_query
+
+
+@mock.patch('inspire_query_parser.parsing_driver.StatefulParser')
+def test_driver_with_nothing_recognized(mocked_parser):
+    query_str = 'unrecognized'
+    expected_es_query = {"match_all": {}}
+
+    mocked_parser.return_value.parse.return_value = ('unrecognized', None)
+
+    es_query = parse_query(query_str)
+
+    assert es_query == expected_es_query
+
+
+@mock.patch('inspire_query_parser.parsing_driver.StatefulParser')
+def test_driver_with_syntax_error(mocked_parser):
+    query_str = 'query with syntax error'
+    expected_es_query = {"match_all": {}}
+
+    mocked_parser.return_value.parse.side_effect = SyntaxError()
+
+    es_query = parse_query(query_str)
+
+    assert es_query == expected_es_query


### PR DESCRIPTION
Adds the driver module, which will be used by Inspire-next. 

_This PR is branched off the ElasticSearchVisitor PR._