### PR TITLE
tests: integrate inspire-next tests

### DIFF
--- a/inspire_query_parser/visitors/elastic_search_visitor.py
+++ b/inspire_query_parser/visitors/elastic_search_visitor.py
@@ -150,7 +150,8 @@ class ElasticSearchVisitor(Visitor):
             'citedby': 'citedby',
             'title': 'titles.title',
             'topcite': 'citation_count',
-            'date': 'earliest_date'
+            'date': 'earliest_date',
+            'refersto': 'references.recid'
         }
 
         # If no keyword is found, return the original node value (case of an unknown keyword).


### PR DESCRIPTION
* Integrates inspire-next query parser related tests, so that it is
  documented that they are now working.
* Add refersto ES field name mapping in ElasticSearch visitor.

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>