### PR TITLE
elasticsearch_visitor: handle value queries

### DIFF
--- a/inspire_query_parser/config.py
+++ b/inspire_query_parser/config.py
@@ -128,12 +128,6 @@ INSPIRE_PARSER_KEYWORDS = {
     'experiment': 'experiment',
     'exp': 'experiment',
 
-    # Field code
-    'field-code': 'field-code',
-    'subject': 'field-code',
-    'fc': 'field-code',
-    'f': 'field-code',
-
     # First-Author
     'first-author': 'first-author',
     'firstauthor': 'first-author',
@@ -198,6 +192,9 @@ INSPIRE_PARSER_KEYWORDS = {
     'rept': 'reportnumber',
     'rn': 'reportnumber',
     'r': 'reportnumber',
+
+    # Subject
+    'subject': 'subject',
 
     # Title
     'title': 'title',

--- a/tests/test_restructuring_visitor.py
+++ b/tests/test_restructuring_visitor.py
@@ -477,7 +477,7 @@ from inspire_query_parser.visitors.restructuring_visitor import \
          )
     ]
 )
-def test_restructuring_visitor(query_str, expected_parse_tree):
+def test_restructuring_visitor_functionality(query_str, expected_parse_tree):
     print("Parsing: " + query_str)
     stateful_parser = StatefulParser()
     restructuring_visitor = RestructuringVisitor()


### PR DESCRIPTION
* Handle Value, PartialMatch and ExactMatch queries (i.e. not as values
  but as queries, e.g. 'ellis, j')
* Add more ElasticSearch fieldnames for the demo.

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>