### PR TITLE
parser: ignore `arxiv:` prefix of simple values

### DIFF
--- a/inspire_query_parser/config.py
+++ b/inspire_query_parser/config.py
@@ -58,7 +58,6 @@ INSPIRE_PARSER_KEYWORDS = {
     # Bulletin
     'bb': 'reportnumber',
     'bull': 'reportnumber',
-    'eprint': 'reportnumber',
 
     # Cataloguer
     'cat': 'cataloguer',
@@ -116,6 +115,9 @@ INSPIRE_PARSER_KEYWORDS = {
 
     # DOI
     'doi': 'doi',
+
+    # ePrint
+    'eprint': 'eprint',
 
     # Exact-Author
     'exact-author': 'exact-author',

--- a/inspire_query_parser/parser.py
+++ b/inspire_query_parser/parser.py
@@ -214,7 +214,7 @@ class SimpleValueUnit(LeafRule):
     """
     token_regex = re.compile(r"[^\s:)(]+", re.UNICODE)
 
-    arxiv_token_regex = re.compile(r"arxiv:" + token_regex.pattern, re.IGNORECASE)
+    arxiv_token_regex = re.compile(r"(arxiv:)(" + token_regex.pattern + ")", re.IGNORECASE)
     """Arxiv identifiers are special cases of tokens where the ":" symbol is allowed."""
 
     date_specifiers_regex = re.compile(r"({})\s*-\s*\d+".format('|'.join(DATE_SPECIFIERS_COLLECTION)), re.UNICODE)
@@ -302,7 +302,7 @@ class SimpleValueUnit(LeafRule):
             # Attempt to parse arxiv identifier
             m = cls.arxiv_token_regex.match(text)
             if m:
-                t, r, found = text[len(m.group(0)):], m.group(0), True
+                t, r, found = text[len(m.group()):], m.group(2), True
             else:
                 # Attempt to parse a terminal token
                 t, r = SimpleValueUnit.parse_terminal_token(parser, text)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -93,12 +93,12 @@ def test_that_parse_terminal_token_does_not_accept_non_shortened_inspire_keyword
         'Canonical arxiv identifier': {
             'query_str': 'arxiv:1706.04080',
             'unrecognized_text': '',
-            'result': SimpleValueUnit('arxiv:1706.04080')
+            'result': SimpleValueUnit('1706.04080')
         },
         'Arxiv identifier with semantically erroneous value (semantic error)': {
             'query_str': 'arxiv:foo',
             'unrecognized_text': '',
-            'result': SimpleValueUnit('arxiv:foo')
+            'result': SimpleValueUnit('foo')
         },
         'Non arxiv-related terminal with colon': {
             'query_str': 'not_arxiv:foo',

--- a/tests/test_restructuring_visitor.py
+++ b/tests/test_restructuring_visitor.py
@@ -591,8 +591,8 @@ def test_restructuring_visitor_functionality(query_str, expected_parse_tree):
             'citedby:recid:902780',
             NestedKeywordOp(Keyword('citedby'), KeywordOp(Keyword('recid'), Value('902780')))
         ),
-        ('eprint:arxiv:1706.04080', KeywordOp(Keyword('reportnumber'), Value('arxiv:1706.04080'))),
-        ('eprint:1706.04080', KeywordOp(Keyword('reportnumber'), Value('1706.04080'))),
+        ('eprint:arxiv:1706.04080', KeywordOp(Keyword('eprint'), Value('1706.04080'))),
+        ('eprint:1706.04080', KeywordOp(Keyword('eprint'), Value('1706.04080'))),
         (
             'f a ostapchenko not olinto not haungs',
             AndOp(


### PR DESCRIPTION
* Ignore `arxiv:` prefix of simple value tokens, since our our data
  don't contain it.
* Make `eprint` keyword resolve to `eprint` and not `reportnumber`.

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>