### PR TITLE
restructuring_visitor: remove flattening of nested keyword query

### DIFF
--- a/inspire_query_parser/visitors/elastic_search_visitor.py
+++ b/inspire_query_parser/visitors/elastic_search_visitor.py
@@ -165,7 +165,7 @@ class ElasticSearchVisitor(Visitor):
         #     }
         # }
         # return [inner_query, outer_query]
-        raise NotImplementedError
+        raise NotImplementedError('Nested keyword queries aren\'t implemented yet.')
 
     def visit_keyword(self, node):
         # TODO This is a temporary solution for handling the Inspire keyword to ElasticSearch fieldname mapping, since
@@ -176,7 +176,7 @@ class ElasticSearchVisitor(Visitor):
             'citedby': 'citedby',
             'collaboration': 'collaborations.value',
             'date': 'earliest_date',
-            'doi': 'dois.value',
+            'doi': 'dois.value.raw',
             'eprint': 'arxiv_eprints.value.raw',
             'refersto': 'references.recid',
             'reportnumber': 'report_numbers.value',

--- a/inspire_query_parser/visitors/restructuring_visitor.py
+++ b/inspire_query_parser/visitors/restructuring_visitor.py
@@ -191,13 +191,6 @@ class RestructuringVisitor(Visitor):
         return KeywordOp(keyword, value)
 
     def visit_nested_keyword_query(self, node):
-        keyword = Keyword(node.left)
-        value = node.right.accept(self)
-        if isinstance(value, ast.Value):
-            # Case of eager identification of a nested keyword query, while the query is a ValueQuery.
-            # Flatten nested keyword query into a simple keyword query.
-            return ast.KeywordOp(keyword, value)
-
         return ast.NestedKeywordOp(Keyword(node.left), node.right.accept(self))
 
     def visit_value(self, node):

--- a/tests/test_restructuring_visitor.py
+++ b/tests/test_restructuring_visitor.py
@@ -194,7 +194,7 @@ from inspire_query_parser.visitors.restructuring_visitor import \
         (
             'refersto:1347300 and (reference:Ellis or reference "Ellis")',
             AndOp(
-                KeywordOp(Keyword('refersto'), Value('1347300')),
+                NestedKeywordOp(Keyword('refersto'), Value('1347300')),
                 OrOp(
                     KeywordOp(Keyword('cite'), Value('Ellis')),
                     KeywordOp(Keyword('cite'), ExactMatchValue('Ellis'))
@@ -313,7 +313,7 @@ from inspire_query_parser.visitors.restructuring_visitor import \
             '-refersto:recid:1374998 and citedby:(A.A.Aguilar.Arevalo.1)',
             AndOp(
                 NotOp(NestedKeywordOp(Keyword('refersto'), KeywordOp(Keyword('recid'), Value('1374998')))),
-                KeywordOp(Keyword('citedby'), Value('A.A.Aguilar.Arevalo.1'))
+                NestedKeywordOp(Keyword('citedby'), Value('A.A.Aguilar.Arevalo.1'))
             )
          ),
         (


### PR DESCRIPTION
* Do not convert `NestedKeywordQuery` to `KeywordOp` query when value
  is a `ValueQuery`.
* Fix `doi` keyword mapping to an ElasticSearch field name.

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>