### PR TITLE
tests: restrict flake8 ignores to what is needed

### DIFF
--- a/inspire_query_parser/__init__.py
+++ b/inspire_query_parser/__init__.py
@@ -24,5 +24,5 @@
 
 from __future__ import absolute_import, print_function
 
-from . import config
-from .parsing_driver import parse_query
+from . import config  # noqa: F401
+from .parsing_driver import parse_query  # noqa: F401

--- a/inspire_query_parser/stateful_pypeg_parser.py
+++ b/inspire_query_parser/stateful_pypeg_parser.py
@@ -19,7 +19,6 @@
 # In applying this license, CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
-import six
 
 from pypeg2 import Parser
 

--- a/inspire_query_parser/visitors/restructuring_visitor.py
+++ b/inspire_query_parser/visitors/restructuring_visitor.py
@@ -37,7 +37,7 @@ from inspire_query_parser.ast import (AndOp, ExactMatchValue, Keyword,
                                       PartialMatchValue,
                                       QueryWithMalformedPart, RegexValue)
 from inspire_query_parser.parser import (And, ComplexValue,
-                                         SimpleValueBooleanQuery, Value)
+                                         SimpleValueBooleanQuery)
 from inspire_query_parser.utils.visitor_utils import \
     DATE_SPECIFIERS_CONVERSION_HANDLERS
 from inspire_query_parser.visitors.visitor_impl import Visitor

--- a/pytest.ini
+++ b/pytest.ini
@@ -22,7 +22,5 @@
 
 [pytest]
 addopts = --cov=inspire_query_parser --cov-report=term-missing:skip-covered --flake8
-flake8-ignore =
-  *.py E121 E123 E126 E128 E501 F401
-  *.py FI12 FI14 FI15 FI16 FI17 FI50 FI51 FI53
+flake8-ignore = E121 E126 E501 F401
 norecursedirs=tests/helpers

--- a/pytest.ini
+++ b/pytest.ini
@@ -22,5 +22,5 @@
 
 [pytest]
 addopts = --cov=inspire_query_parser --cov-report=term-missing:skip-covered --flake8
-flake8-ignore = E121 E126 E501 F401
+flake8-ignore = E121 E126 E501
 norecursedirs=tests/helpers

--- a/tests/test_elastic_search_visitor.py
+++ b/tests/test_elastic_search_visitor.py
@@ -26,10 +26,8 @@ from __future__ import print_function, unicode_literals
 import mock
 import pytest
 
-import inspire_query_parser
 from inspire_query_parser import parser
-from inspire_query_parser.config import (DEFAULT_ES_OPERATOR_FOR_MALFORMED_QUERIES,
-                                         ES_MUST_QUERY, ES_SHOULD_QUERY)
+from inspire_query_parser.config import ES_MUST_QUERY, ES_SHOULD_QUERY
 from inspire_query_parser.stateful_pypeg_parser import StatefulParser
 from inspire_query_parser.visitors.elastic_search_visitor import \
     ElasticSearchVisitor


### PR DESCRIPTION
You unfortunately copied the configuration of INSPIRE before I managed to clean most of the errors, which meant you had ignores for things that shouldn't be ignored. Check the configuration today: https://github.com/inspirehep/inspire-next/blob/096666d85a2232f1f58692831b288ffaa78d3a16/pytest.ini#L25

In particular, we want to ignore `E501` (line length), but we don't want to ignore the others. The `FI` ones check the `__future__` imports, which are not uniform in this project, but are used correctly AFAICT. The only serious one is `F401`. See for example https://github.com/inspirehep/inspire-next/pull/2708 to see what kind of errors it can hide.