### PR TITLE
parser: support more value types for = sign

### DIFF
--- a/inspire_query_parser/parser.py
+++ b/inspire_query_parser/parser.py
@@ -597,16 +597,20 @@ class Value(UnaryRule):
     Serves as an encapsulation of the listed rules.
     """
     grammar = attr('op', [
-        (omit(Literal("=")), SimpleValue),
-        RangeOp,
+        (optional(omit(Literal("="))), RangeOp),
         GreaterEqualOp,
         LessEqualOp,
         GreaterThanOp,
         LessThanOp,
-        ComplexValue,
-        ParenthesizedSimpleValues,
-        SimpleValueBooleanQuery,
-        SimpleValue,
+        (
+            optional(omit(Literal("="))),
+            [
+                ComplexValue,
+                ParenthesizedSimpleValues,
+                SimpleValueBooleanQuery,
+                SimpleValue
+            ]
+        )
     ])
 ########################
 


### PR DESCRIPTION
* Add support for '=' for more value types, as previously was only for
  SimpleValues.

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>