### PR TITLE
es_visitor: update `subject` fieldname mapping

### DIFF
--- a/inspire_query_parser/visitors/elastic_search_visitor.py
+++ b/inspire_query_parser/visitors/elastic_search_visitor.py
@@ -204,7 +204,7 @@ class ElasticSearchVisitor(Visitor):
             'eprint': 'arxiv_eprints.value.raw',
             'refersto': 'references.recid',
             'reportnumber': 'report_numbers.value.fuzzy',
-            'subject': 'inspire_categories.term',
+            'subject': 'facet_inspire_categories',
             'title': 'titles.full_title',
             'type-code': 'document_type',
             'topcite': 'citation_count',


### PR DESCRIPTION
The fieldname mapping `inspire_categories.term` is analyzed, although
for this kind of search we want it to be not analyzed.

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>

@jacquerie 
Do you think using `facet_*` field is ok? 
Or should I create in the hep mapping, under `inspire_categories`, another child field called `raw` with `"index": "not_analyzed"`?