### PR TITLE
setup: bump pytest-flake8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ docs_require = []
 tests_require = [
     'mock~=2.0,>=2.0.0',
     'pytest-cov~=2.0,>=2.5.1',
-    'pytest-flake8~=0.0,>=0.8.1',
+    'pytest-flake8~=0.0,>=0.9',
     'pytest~=3.0,>=3.2.2',
 ]
 


### PR DESCRIPTION
The previous version of ``pytest-flake8`` was incompatible with the
latest version of ``flake8``, so we bump the former.

Closes https://github.com/inspirehep/inspire-query-parser/pull/39.