### PR TITLE
parser: add texkey support

### DIFF
--- a/inspire_query_parser/stateful_pypeg_parser.py
+++ b/inspire_query_parser/stateful_pypeg_parser.py
@@ -36,9 +36,13 @@ class StatefulParser(Parser):
             Signifies whether we are parsing a parenthesized simple values expression. Used for disabling the simple
             values parsing related check "stop on INSPIRE keyword", for allowing parsing more expressions and not
             restrict the input accepted by the parser.
+
+        _parsing_texkey_expression (bool):
+            Signifies whether we are parsing a `texkey` expression which has special value in which we must accept ':'.
     """
 
     def __init__(self):
         super(StatefulParser, self).__init__()
         self._parsing_parenthesized_terminal = False
         self._parsing_parenthesized_simple_values_expression = False
+        self._parsing_texkey_expression = False

--- a/tests/test_parser_functionality.py
+++ b/tests/test_parser_functionality.py
@@ -334,6 +334,24 @@ from inspire_query_parser.stateful_pypeg_parser import StatefulParser
          Query([Statement(Expression(SimpleQuery(
              SpiresKeywordQuery(InspireKeyword('title'), Value(SimpleValue('C-12(vec-p,vec-n)N-12 (g.s.,1+)'))))))])
          ),
+        ('find texkey Hirata:1992ku',
+         Query([Statement(Expression(SimpleQuery(
+             SpiresKeywordQuery(
+                 InspireKeyword('texkey'),
+                 Value(SimpleValue('Hirata:1992ku'))))))])
+         ),
+        ('find texkey:Hirata:1992ku',
+         Query([Statement(Expression(SimpleQuery(
+             InvenioKeywordQuery(
+                 InspireKeyword('texkey'),
+                 Value(SimpleValue('Hirata:1992ku'))))))])
+         ),
+        ('find texkey Hirata:1992*',
+         Query([Statement(Expression(SimpleQuery(
+             SpiresKeywordQuery(
+                 InspireKeyword('texkey'),
+                 Value(SimpleValue('Hirata:1992*'))))))])
+         ),
 
         # Regex
         ('author:/^Ellis, (J|John)$/',

--- a/tests/test_restructuring_visitor.py
+++ b/tests/test_restructuring_visitor.py
@@ -442,7 +442,7 @@ from inspire_query_parser.visitors.restructuring_visitor import \
             )
          ),
 
-        # Star queries
+        # Wildcard queries
         (
             'find a \'o*aigh\' and t "alge*" and date >2013',
             AndOp(
@@ -465,6 +465,10 @@ from inspire_query_parser.visitors.restructuring_visitor import \
                 )
             )
          ),
+        (
+            'find texkey Hirata:1992*',
+            KeywordOp(Keyword('texkey'), Value('Hirata:1992*', contains_wildcard=True))
+        ),
 
         # Unrecognized queries
         ('title and foo', MalformedQuery(['title', 'and', 'foo'])),


### PR DESCRIPTION
* Add support for texkey queries (special case for its values, since a
  ':' symbol needs to be accepted - not the usual case).

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>