### PR TITLE
es_visitor: refactor multi-field range queries

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup_requires = [
 ]
 
 install_requires=[
+    'inspire-utils~=0.2,>=0.2.0',
     'pypeg2~=2.0,>=2.15.2',
     'python-dateutil~=2.0,>=2.6.1',
     'six~=1.0,>=1.11.0',


### PR DESCRIPTION
Use ES range query for supporting any type of range queries (bounded or unbounded).

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>