### PR TITLE
es-visitor: dynamic select name variations field

### DIFF
--- a/inspire_query_parser/visitors/elastic_search_visitor.py
+++ b/inspire_query_parser/visitors/elastic_search_visitor.py
@@ -71,7 +71,8 @@ class ElasticSearchVisitor(Visitor):
         'topcite': 'citation_count',
     }
 
-    AUTHORS_NAME_VARIATIONS_FIELD = 'authors.name_variations'
+    AUTHORS_ALL_NAME_VARIATIONS_FIELD = 'authors.name_variations.all'
+    AUTHORS_SPECIFIC_NAME_VARIATIONS_FIELD = 'authors.name_variations.specific'
 
     def _generate_author_query(self, author_name):
         """Generates a match and a filter query handling specifically authors.
@@ -84,12 +85,19 @@ class ElasticSearchVisitor(Visitor):
         # if self.generating_not_query:
         #     raise ValueError("Should not be using this method when generating a not query for authors.")
         name_variations = generate_name_variations(author_name)
+
+        name_variations_field = (
+            ElasticSearchVisitor.AUTHORS_ALL_NAME_VARIATIONS_FIELD
+            if len(name_variations) == 1
+            else ElasticSearchVisitor.AUTHORS_SPECIFIC_NAME_VARIATIONS_FIELD
+        )
+
         return {
             "bool": {
                 "filter": {
                     "bool": {
                         "should": [
-                            {"term": {ElasticSearchVisitor.AUTHORS_NAME_VARIATIONS_FIELD: name_variation}}
+                            {"term": {name_variations_field: name_variation}}
                             for name_variation in name_variations
                         ]
                     }

--- a/tests/test_elastic_search_visitor.py
+++ b/tests/test_elastic_search_visitor.py
@@ -73,6 +73,30 @@ def test_elastic_search_visitor_find_author_exact_value_ellis():
     assert generated_es_query == expected_es_query
 
 
+def test_elastic_search_visitor_find_author_generic_search():
+    query_str = 'f author Ellis'
+    expected_es_query = \
+        {
+            "bool": {
+                "filter": {
+                    "bool": {
+                        "should": [
+                            {"term": {ElasticSearchVisitor.AUTHORS_ALL_NAME_VARIATIONS_FIELD: 'Ellis'}}
+                        ]
+                    }
+                },
+                "must": {
+                    "match": {
+                        "authors.full_name": "Ellis"
+                    }
+                }
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
 def test_elastic_search_visitor_find_author_simple_value_ellis():
     author_name = 'Ellis, John'
     name_variations = generate_name_variations(author_name)
@@ -83,7 +107,14 @@ def test_elastic_search_visitor_find_author_simple_value_ellis():
                 "filter": {
                     "bool": {
                         "should": [
-                            {"term": {"authors.name_variations": name_variation}} for name_variation in name_variations
+                            {
+                                "term": {
+                                    ElasticSearchVisitor.AUTHORS_SPECIFIC_NAME_VARIATIONS_FIELD:
+                                        name_variation
+                                }
+                            }
+                            for name_variation
+                            in name_variations
                         ]
                     }
                 },
@@ -113,7 +144,12 @@ def test_elastic_search_visitor_and_op_query():
                             "filter": {
                                 "bool": {
                                     "should": [
-                                        {"term": {"authors.name_variations": name_variation}}
+                                        {
+                                            "term": {
+                                                ElasticSearchVisitor.AUTHORS_SPECIFIC_NAME_VARIATIONS_FIELD:
+                                                    name_variation
+                                            }
+                                        }
                                         for name_variation
                                         in name_variations
                                     ]
@@ -153,7 +189,12 @@ def test_elastic_search_visitor_or_op_query():
                             "filter": {
                                 "bool": {
                                     "should": [
-                                        {"term": {"authors.name_variations": name_variation}}
+                                        {
+                                            "term": {
+                                                ElasticSearchVisitor.AUTHORS_SPECIFIC_NAME_VARIATIONS_FIELD:
+                                                    name_variation
+                                            }
+                                        }
                                         for name_variation
                                         in name_variations
                                     ]
@@ -339,7 +380,12 @@ def test_elastic_search_visitor_not_op():
                         "filter": {
                             "bool": {
                                 "should": [
-                                    {"term": {"authors.name_variations": name_variation}}
+                                    {
+                                        "term": {
+                                            ElasticSearchVisitor.AUTHORS_SPECIFIC_NAME_VARIATIONS_FIELD:
+                                                name_variation
+                                        }
+                                    }
                                     for name_variation
                                     in name_variations
                                 ]

--- a/tests/test_parsing_driver.py
+++ b/tests/test_parsing_driver.py
@@ -39,7 +39,9 @@ def test_driver_with_simple_query():
             "filter": {
                 "bool": {
                     "should": [
-                        {"term": {"authors.name_variations": name_variation}} for name_variation in name_variations
+                        {"term": {"authors.name_variations.specific": name_variation}}
+                        for name_variation
+                        in name_variations
                     ]
                 }
             },


### PR DESCRIPTION
Dynamically select which of the two name variation fields to query
depending on user's input (either all name variations or specific
ones). If user provides only one name, then query the `all` name
variations field, otherwise the more specific one.

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>