### PR TITLE
config: change `recid` mapping

### DIFF
--- a/inspire_query_parser/config.py
+++ b/inspire_query_parser/config.py
@@ -89,6 +89,10 @@ INSPIRE_PARSER_KEYWORDS = {
     # Conference number
     'cnum': 'confnumber',
 
+    # Control number
+    'control_number': 'control_number',
+    'recid': 'control_number',
+
     # Country
     'country': 'country',
     'cc': 'country',
@@ -171,9 +175,6 @@ INSPIRE_PARSER_KEYWORDS = {
 
     # rawref
     'rawref': 'rawref',
-
-    # recid
-    'recid': 'recid',
 
     # Reference
     'citation': 'reference',

--- a/tests/test_restructuring_visitor.py
+++ b/tests/test_restructuring_visitor.py
@@ -312,7 +312,7 @@ from inspire_query_parser.visitors.restructuring_visitor import \
         (
             '-refersto:recid:1374998 and citedby:(A.A.Aguilar.Arevalo.1)',
             AndOp(
-                NotOp(NestedKeywordOp(Keyword('refersto'), KeywordOp(Keyword('recid'), Value('1374998')))),
+                NotOp(NestedKeywordOp(Keyword('refersto'), KeywordOp(Keyword('control_number'), Value('1374998')))),
                 NestedKeywordOp(Keyword('citedby'), Value('A.A.Aguilar.Arevalo.1'))
             )
          ),
@@ -330,7 +330,7 @@ from inspire_query_parser.visitors.restructuring_visitor import \
             'citedby:refersto:recid:1432705',
             NestedKeywordOp(
                 Keyword('citedby'),
-                NestedKeywordOp(Keyword('refersto'), KeywordOp(Keyword('recid'), Value('1432705')))
+                NestedKeywordOp(Keyword('refersto'), KeywordOp(Keyword('control_number'), Value('1432705')))
             )
          ),
 
@@ -593,7 +593,7 @@ def test_restructuring_visitor_functionality(query_str, expected_parse_tree):
         ),
         (
             'citedby:recid:902780',
-            NestedKeywordOp(Keyword('citedby'), KeywordOp(Keyword('recid'), Value('902780')))
+            NestedKeywordOp(Keyword('citedby'), KeywordOp(Keyword('control_number'), Value('902780')))
         ),
         ('eprint:arxiv:1706.04080', KeywordOp(Keyword('eprint'), Value('1706.04080'))),
         ('eprint:1706.04080', KeywordOp(Keyword('eprint'), Value('1706.04080'))),


### PR DESCRIPTION
Map `recid` to `control_number`, while also adding a keyword mapping for `control_number` (Adresses https://github.com/inspirehep/inspire-query-parser/issues/57).

Signed-off-by: Iuliana Voinea <iuliana.voinea@student.manchester.ac.uk>