### PR TITLE
es-visitor: improve authors search

### DIFF
--- a/tests/test_parsing_driver.py
+++ b/tests/test_parsing_driver.py
@@ -24,29 +24,16 @@ from __future__ import absolute_import, unicode_literals
 
 import mock
 
-from inspire_utils.name import generate_name_variations
-
 from inspire_query_parser.parsing_driver import parse_query
 
 
 def test_driver_with_simple_query():
-    author_name = 'Ellis, John'
-    name_variations = generate_name_variations(author_name)
-
-    query_str = 'author: ' + author_name
+    query_str = 'subject astrophysics'
     expected_es_query = {
-        "bool": {
-            "filter": {
-                "bool": {
-                    "should": [
-                        {"term": {"authors.name_variations": name_variation}} for name_variation in name_variations
-                    ]
-                }
-            },
-            "must": {
-                "match": {
-                    "authors.full_name": "Ellis, John"
-                }
+        "match": {
+            "facet_inspire_categories": {
+                "query": "astrophysics",
+                "operator": "and"
             }
         }
     }


### PR DESCRIPTION
~This is a WIP PR for tracking the progress of improving authors searching.~
Improves author search by making it more conservative on what records
it returns (more like legacy) (addresses inspirehep/inspire-next#3055).

For this, we employ two different kind of queries:
- If the given author name parts are all in full (i.e. no initials, or
  not only lastnames), then we generate minimal name variations in
  order to match with the broader ones (during index time).

  Additionally, in this case, we require for the fullname, to matches
  all the provided name parts. Thus, being able to filter out authors
  with same lastname and similar prefix firstnames (e.g. 'Mele,
  Salavtore' and 'Mele, Samuele').

- Otherwise, on initials or lastnames only, fallback to filtering only
  with the minimal name variations.
