### PR TITLE
es-visitor: support exact-author queries

### DIFF
--- a/tests/test_elastic_search_visitor.py
+++ b/tests/test_elastic_search_visitor.py
@@ -112,6 +112,123 @@ def test_elastic_search_visitor_find_spires_identifier_simple_value():
     assert generated_es_query == expected_es_query
 
 
+def test_elastic_search_visitor_find_exact_author_simple_value():
+    query_str = 'ea Vures, John I.'
+    expected_es_query = \
+        {
+            "term": {
+                "authors.full_name_normalized": "vures, john i."
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_find_exact_author_simple_value_diacritics():
+    query_str = 'ea Vurës, John I'
+    expected_es_query = \
+        {
+            "term": {
+                "authors.full_name_normalized": "vur\xebs, john i."
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_find_exact_author_partial_value():
+    query_str = "ea 'Vures, John I.'"
+    expected_es_query = \
+        {
+            "term": {
+                "authors.full_name_normalized": "vures, john i."
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_find_exact_author_partial_value_diacritics():
+    query_str = "ea 'Vurës, John I'"
+    expected_es_query = \
+        {
+            "term": {
+                "authors.full_name_normalized": "vur\xebs, john i."
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_find_exact_author_exact_value():
+    query_str = 'ea "Vures, John I."'
+    expected_es_query = \
+        {
+            "term": {
+                "authors.full_name_normalized": "vures, john i."
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_find_exact_author_exact_value_diacritics():
+    query_str = 'ea "Vurës, John I"'
+    expected_es_query = \
+        {
+            "term": {
+                "authors.full_name_normalized": "vur\xebs, john i."
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_find_exact_author_with_bai_simple_value_ellis():
+    query_str = 'ea J.Ellis.4'
+    expected_es_query = \
+        {
+            "term": {
+                "authors.ids.value.raw": "J.Ellis.4"
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_find_exact_author_with_bai_exact_value_ellis():
+    query_str = 'ea "J.Ellis.4"'
+    expected_es_query = \
+        {
+            "term": {
+                "authors.ids.value.raw": "J.Ellis.4"
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_find_exact_author_with_bai_partial_value_ellis():
+    query_str = "ea 'J.Ellis.4'"
+    expected_es_query = \
+        {
+            "term": {
+                "authors.ids.value.raw": "J.Ellis.4"
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
 def test_elastic_search_visitor_and_op_query():
     author_name = 'Ellis, John'
     name_variations = generate_name_variations(author_name)

--- a/tests/test_restructuring_visitor.py
+++ b/tests/test_restructuring_visitor.py
@@ -516,11 +516,7 @@ def test_restructuring_visitor_functionality(query_str, expected_parse_tree):
             )
         ),
         ('a kondrashuk', KeywordOp(Keyword('author'), Value('kondrashuk'))),
-        pytest.param(
-            'a r.j.hill.1',
-            KeywordOp(Keyword('exact-author'), Value('r.j.hill.1')),
-            marks=pytest.mark.xfail(reason="Keyword used should be exact-author (since value is a BAI).")
-        ),
+        ('a r.j.hill.1', KeywordOp(Keyword('author'), Value('r.j.hill.1'))),
         (
             'a fileviez perez,p or p. f. perez',
             OrOp(
@@ -562,11 +558,7 @@ def test_restructuring_visitor_functionality(query_str, expected_parse_tree):
                 )
             )
         ),
-        pytest.param(
-            'ea wu, xing gang',
-            KeywordOp(Keyword('author'), Value('wu, xing gang')),
-            marks=pytest.mark.xfail(reason="Keyword should be author (with this kind of value).")
-        ),
+        ('ea wu, xing gang', KeywordOp(Keyword('exact-author'), Value('wu, xing gang'))),
         ('abstract: part*', KeywordOp(Keyword('abstract'), Value('part*', contains_wildcard=True))),
         (
             "(author:'Hiroshi Okada' OR (author:'H Okada' hep-ph) OR "
@@ -593,11 +585,7 @@ def test_restructuring_visitor_functionality(query_str, expected_parse_tree):
                 ValueOp(Value('hep-th/0010101'))
             )
         ),
-        pytest.param(
-            'ea:matt visser',
-            KeywordOp(Keyword('author'), Value('matt visser')),
-            marks=pytest.mark.xfail(reason="Keyword should be author (with this kind of value).")
-        ),
+        ('ea:matt visser', KeywordOp(Keyword('exact-author'), Value('matt visser'))),
         (
             'citedby:recid:902780',
             NestedKeywordOp(Keyword('citedby'), KeywordOp(Keyword('control_number'), Value('902780')))


### PR DESCRIPTION
## Description
I added functionality to the es-visitor that supports `exact-author` queries, i.e. when someone writes a query of the form `ea Ellis, J`, or any other acceptable variation of `exact-author`, the visitor will check whether the value is a bai. Then, it will perform a `term` query on the appropriate field, `authors.full_name.raw` for author names and `authors.ids.value` for bais. These fields are not analysed, therefore the probablility of an exact match is high, as both the indexed value and the queried value are normalized by the same normalizers that Inspire uses, and no ES specific normalizer or filter is applied, thus the entire author name/bai is indexed as a single term.

## Related Issue
https://github.com/inspirehep/inspire-query-parser/issues/63

## Related PR
https://github.com/inspirehep/inspire-next/pull/3064

## Motivation and Context
This functionality is needed because we are required to support exact-author queries as they were implemented in legacy.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: Iuliana Voinea <iuliana.voinea@student.manchester.ac.uk>