### PR TITLE
rst-visitor: wrap Value with ValueOp

### DIFF
--- a/inspire_query_parser/ast.py
+++ b/inspire_query_parser/ast.py
@@ -139,7 +139,7 @@ class NestedKeywordOp(BinaryOp):
     pass
 
 
-class ValueQuery(UnaryOp):
+class ValueOp(UnaryOp):
     pass
 
 

--- a/inspire_query_parser/visitors/elastic_search_visitor.py
+++ b/inspire_query_parser/visitors/elastic_search_visitor.py
@@ -207,7 +207,7 @@ class ElasticSearchVisitor(Visitor):
     def visit_empty_query(self, node):
         return {'match_all': {}}
 
-    def visit_value_query(self, node):
+    def visit_value_op(self, node):
         return {
             'match': {
                 "_all": node.op.value

--- a/inspire_query_parser/visitors/restructuring_visitor.py
+++ b/inspire_query_parser/visitors/restructuring_visitor.py
@@ -98,7 +98,7 @@ class RestructuringVisitor(Visitor):
                     or isinstance(result, ast.PartialMatchValue) \
                     or isinstance(result, ast.RegexValue):
                 # The only Values that can be standalone queries are the above.
-                return ast.ValueQuery(result)
+                return ast.ValueOp(result)
         else:
             # Case in which we have both a recognized query and a malformed one.
             return QueryWithMalformedPart(result[0], result[1])

--- a/inspire_query_parser/visitors/restructuring_visitor.py
+++ b/inspire_query_parser/visitors/restructuring_visitor.py
@@ -35,7 +35,7 @@ from inspire_query_parser import ast
 from inspire_query_parser.ast import (AndOp, ExactMatchValue, Keyword,
                                       KeywordOp, NotOp, OrOp,
                                       PartialMatchValue,
-                                      QueryWithMalformedPart, RegexValue)
+                                      QueryWithMalformedPart, RegexValue, ValueOp)
 from inspire_query_parser.parser import (And, ComplexValue,
                                          SimpleValueBooleanQuery)
 from inspire_query_parser.utils.visitor_utils import \
@@ -48,14 +48,12 @@ logger = logging.getLogger(__name__)
 def _convert_simple_value_boolean_query_to_and_boolean_queries(tree, keyword):
     """Chain SimpleValueBooleanQuery values into chained AndOp queries with the given current Keyword."""
 
-    def _create_keyword_op_node(value_node):
-        """Creates a KeywordOp node, with the given Keyword argument and the given Value node of the closure."""
-        if isinstance(value_node, NotOp):
-            keyword_op_node = NotOp(KeywordOp(keyword, value_node.op))
-        else:
-            keyword_op_node = KeywordOp(keyword, value_node)
+    def _create_operator_node(value_node):
+        """Creates a KeywordOp or a ValueOp node."""
+        base_node = value_node.op if isinstance(value_node, NotOp) else value_node
+        updated_base_node = KeywordOp(keyword, base_node) if keyword else ValueOp(base_node)
 
-        return keyword_op_node
+        return NotOp(updated_base_node) if isinstance(value_node, NotOp) else updated_base_node
 
     def _get_bool_op_type(bool_op):
         return AndOp if isinstance(bool_op, And) else OrOp
@@ -65,10 +63,10 @@ def _convert_simple_value_boolean_query_to_and_boolean_queries(tree, keyword):
     previous_tree = tree
 
     while True:  # Walk down the tree while building the new AndOp queries subtree.
-        current_tree.left = _create_keyword_op_node(previous_tree.left) if keyword else previous_tree.left
+        current_tree.left = _create_operator_node(previous_tree.left)
 
         if not isinstance(previous_tree.right, SimpleValueBooleanQuery):
-            current_tree.right = _create_keyword_op_node(previous_tree.right) if keyword else previous_tree.right
+            current_tree.right = _create_operator_node(previous_tree.right)
             break
 
         previous_tree = previous_tree.right
@@ -145,6 +143,9 @@ class RestructuringVisitor(Visitor):
         if isinstance(node, SimpleValueBooleanQuery):
             # Case in which the node is a simple value boolean query not paired with a keyword query. e.g. 'foo and bar'
             return _convert_simple_value_boolean_query_to_and_boolean_queries(node, None)
+        elif isinstance(node, ast.Value):
+            # Case in which the node is a SimpleQuery(Value(...)) e.g. for a value query "Ellis"
+            return ast.ValueOp(node)
 
         return node
 

--- a/tests/test_restructuring_visitor.py
+++ b/tests/test_restructuring_visitor.py
@@ -135,6 +135,13 @@ from inspire_query_parser.visitors.restructuring_visitor import \
                 NotOp(KeywordOp(Keyword('title'), PartialMatchValue('boson')))
             )
          ),
+        (
+                'topcite 2+ and skands',
+                AndOp(
+                    KeywordOp(Keyword('topcite'), GreaterEqualThanOp(Value('2'))),
+                    ValueOp(Value('skands'))
+                )
+        ),
 
         # ##### Boolean operators at terminals level ####
         (
@@ -152,7 +159,7 @@ from inspire_query_parser.visitors.restructuring_visitor import \
         (
             'ellis and not title \'boson\'',
             AndOp(
-                Value('ellis'),
+                ValueOp(Value('ellis')),
                 NotOp(KeywordOp(Keyword('title'), PartialMatchValue('boson')))
             )
          ),
@@ -194,7 +201,7 @@ from inspire_query_parser.visitors.restructuring_visitor import \
         (
             'refersto:1347300 and (reference:Ellis or reference "Ellis")',
             AndOp(
-                NestedKeywordOp(Keyword('refersto'), Value('1347300')),
+                NestedKeywordOp(Keyword('refersto'), ValueOp(Value('1347300'))),
                 OrOp(
                     KeywordOp(Keyword('cite'), Value('Ellis')),
                     KeywordOp(Keyword('cite'), ExactMatchValue('Ellis'))
@@ -212,7 +219,7 @@ from inspire_query_parser.visitors.restructuring_visitor import \
         # Simple phrases
         ('ellis', ValueOp(Value('ellis'))),
         ('\'ellis\'', ValueOp(PartialMatchValue('ellis'))),
-        ('(ellis and smith)', AndOp(Value('ellis'), Value('smith'))),
+        ('(ellis and smith)', AndOp(ValueOp(Value('ellis')), ValueOp(Value('smith')))),
 
         # Parenthesized keyword query values (working also with SPIRES operators - doesn't on legacy)
         (
@@ -313,7 +320,7 @@ from inspire_query_parser.visitors.restructuring_visitor import \
             '-refersto:recid:1374998 and citedby:(A.A.Aguilar.Arevalo.1)',
             AndOp(
                 NotOp(NestedKeywordOp(Keyword('refersto'), KeywordOp(Keyword('control_number'), Value('1374998')))),
-                NestedKeywordOp(Keyword('citedby'), Value('A.A.Aguilar.Arevalo.1'))
+                NestedKeywordOp(Keyword('citedby'), ValueOp(Value('A.A.Aguilar.Arevalo.1')))
             )
          ),
         (
@@ -497,14 +504,14 @@ def test_restructuring_visitor_functionality(query_str, expected_parse_tree):
         (
             'sungtae cho or 1301.7261',
             OrOp(
-                Value('sungtae cho'),
-                Value('1301.7261')
+                ValueOp(Value('sungtae cho')),
+                ValueOp(Value('1301.7261'))
             )
         ),
         (
             'raffaele d\'agnolo and not cn cms',
             AndOp(
-                Value('raffaele d\'agnolo'),
+                ValueOp(Value('raffaele d\'agnolo')),
                 NotOp(KeywordOp(Keyword('collaboration'), Value('cms')))
             )
         ),
@@ -570,7 +577,7 @@ def test_restructuring_visitor_functionality(query_str, expected_parse_tree):
                 OrOp(
                     AndOp(
                         KeywordOp(Keyword('author'), PartialMatchValue('H Okada')),
-                        Value('hep-ph')
+                        ValueOp(Value('hep-ph'))
                     ),
                     OrOp(
                         KeywordOp(Keyword('title'), PartialMatchValue('Dark matter in supersymmetric U(1(B-L) model')),
@@ -583,7 +590,7 @@ def test_restructuring_visitor_functionality(query_str, expected_parse_tree):
             'author:"Takayanagi, Tadashi" or hep-th/0010101',
             OrOp(
                 KeywordOp(Keyword('author'), ExactMatchValue('Takayanagi, Tadashi')),
-                Value('hep-th/0010101')
+                ValueOp(Value('hep-th/0010101'))
             )
         ),
         pytest.param(

--- a/tests/test_restructuring_visitor.py
+++ b/tests/test_restructuring_visitor.py
@@ -35,7 +35,7 @@ from inspire_query_parser.ast import (AndOp, EmptyQuery, ExactMatchValue,
                                       NestedKeywordOp, NotOp, OrOp,
                                       PartialMatchValue,
                                       QueryWithMalformedPart, RangeOp,
-                                      RegexValue, Value, ValueQuery)
+                                      RegexValue, Value, ValueOp)
 from inspire_query_parser.stateful_pypeg_parser import StatefulParser
 from inspire_query_parser.visitors.restructuring_visitor import \
     RestructuringVisitor
@@ -210,8 +210,8 @@ from inspire_query_parser.visitors.restructuring_visitor import \
         ),
 
         # Simple phrases
-        ('ellis', ValueQuery(Value('ellis'))),
-        ('\'ellis\'', ValueQuery(PartialMatchValue('ellis'))),
+        ('ellis', ValueOp(Value('ellis'))),
+        ('\'ellis\'', ValueOp(PartialMatchValue('ellis'))),
         ('(ellis and smith)', AndOp(Value('ellis'), Value('smith'))),
 
         # Parenthesized keyword query values (working also with SPIRES operators - doesn't on legacy)


### PR DESCRIPTION
This is towards more consistency to the `AST` naming scheme:
- Firstly, renaming `ValueQuery` to `ValueOp`, so as to follow the same convention with `KeywordOp` (they have the "level" semantics in the parse tree hierarchy).
- Wrap all `Value`s _(that are not part of keyword queries)_ with `ValueOp` nodes, in order to have uniform handling for nodes of the same hierarchy (also, for readability).  
For example, we have `NotOp(KeywordOp(Keyword('author'), Value('ellis')))` and we **had** `NotOp(Value('ellis'))`. The latter one is now transformed into `NotOp(ValueOp(Value('ellis')))`.  
