### PR TITLE
es-visitor: `"operator": "and"` in `match` queries

### DIFF
--- a/inspire_query_parser/visitors/elastic_search_visitor.py
+++ b/inspire_query_parser/visitors/elastic_search_visitor.py
@@ -210,7 +210,10 @@ class ElasticSearchVisitor(Visitor):
     def visit_value_op(self, node):
         return {
             'match': {
-                "_all": node.op.value
+                "_all": {
+                    "query": node.op.value,
+                    "operator": "and",
+                }
             }
         }
 
@@ -320,7 +323,10 @@ class ElasticSearchVisitor(Visitor):
 
                 return {
                     'match': {
-                        fieldnames: node.value,
+                        fieldnames: {
+                            "query": node.value,
+                            "operator": "and",
+                        }
                     }
                 }
 

--- a/tests/test_elastic_search_visitor.py
+++ b/tests/test_elastic_search_visitor.py
@@ -128,7 +128,10 @@ def test_elastic_search_visitor_and_op_query():
                     },
                     {
                         "match": {
-                            "titles.full_title": "boson"
+                            "titles.full_title": {
+                                "query": "boson",
+                                "operator": "and",
+                            }
                         }
                     }
                 ]
@@ -168,7 +171,10 @@ def test_elastic_search_visitor_or_op_query():
                     },
                     {
                         "match": {
-                            "titles.full_title": "boson"
+                            "titles.full_title": {
+                                "query":  "boson",
+                                "operator": "and",
+                            }
                         }
                     }
                 ]
@@ -183,7 +189,10 @@ def test_elastic_search_visitor_unknown_keyword_simple_value():
     query_str = 'unknown_keyword:bar'
     expected_es_query = {
         "match": {
-            "unknown_keyword": "bar"
+            "unknown_keyword": {
+                "query": "bar",
+                "operator": "and",
+            }
         }
     }
 
@@ -195,7 +204,10 @@ def test_elastic_search_visitor_dotted_keyword_simple_value():
     query_str = 'dotted.keyword:bar'
     expected_es_query = {
         "match": {
-            "dotted.keyword": "bar"
+            "dotted.keyword": {
+                "query":  "bar",
+                "operator": "and",
+            }
         }
     }
 
@@ -207,7 +219,10 @@ def test_elastic_search_visitor_value_query():
     query_str = 'foo bar'
     expected_es_query = {
         "match": {
-            "_all": "foo bar"
+            "_all": {
+                "query": "foo bar",
+                "operator": "and",
+            }
         }
     }
 
@@ -230,7 +245,10 @@ def test_elastic_search_visitor_keyword_query_and_value_query():
                     },
                     {
                         "match": {
-                            "_all": "skands"
+                            "_all": {
+                                "query": "skands",
+                                "operator": "and",
+                            }
                         }
                     }
                 ]
@@ -472,7 +490,10 @@ def test_elastic_search_visitor_with_query_with_malformed_part_and_default_malfo
                 "must": [
                     {
                         "match": {
-                            "titles.full_title": "γ-radiation"
+                            "titles.full_title": {
+                                "query": "γ-radiation",
+                                "operator": "and",
+                            }
                         }
                     },
                     {
@@ -500,7 +521,10 @@ def test_elastic_search_visitor_with_query_with_malformed_part_and_default_malfo
                 "must": [
                     {
                         "match": {
-                            "titles.full_title": "γ-radiation"
+                            "titles.full_title": {
+                                "query": "γ-radiation",
+                                "operator": "and",
+                            }
                         }
                     }
                 ],
@@ -666,7 +690,10 @@ def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_gt_
                 "must": [
                     {
                         "match": {
-                            "titles.full_title": "γ-radiation"
+                            "titles.full_title": {
+                                "query": "γ-radiation",
+                                "operator": "and",
+                            }
                         }
                     },
                     {
@@ -694,7 +721,10 @@ def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_gte
                 "must": [
                     {
                         "match": {
-                            "titles.full_title": "γ-radiation"
+                            "titles.full_title": {
+                                "query": "γ-radiation",
+                                "operator": "and",
+                            }
                         }
                     },
                     {
@@ -722,7 +752,10 @@ def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_lt_
                 "must": [
                     {
                         "match": {
-                            "titles.full_title": "γ-radiation"
+                            "titles.full_title": {
+                                "query": "γ-radiation",
+                                "operator": "and",
+                            }
                         }
                     },
                     {
@@ -750,7 +783,10 @@ def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_lte
                 "must": [
                     {
                         "match": {
-                            "titles.full_title": "γ-radiation"
+                            "titles.full_title": {
+                                "query": "γ-radiation",
+                                "operator": "and",
+                            }
                         }
                     },
                     {


### PR DESCRIPTION
Use ``"operator": "and"`` in ``match`` queries for making sure that if
multiple words are provided, they all must show up in the queried field
(addresses inspirehep/inspire-next#3048).

This was motivated due to `title` queries (inspirehep/inspire-next#3048), but also matches our goals for "more exact" (similar to legacy) results.

Branched off from #67.