### PR TITLE
es-visitor: support `irn` simple value queries

### DIFF
--- a/inspire_query_parser/config.py
+++ b/inspire_query_parser/config.py
@@ -145,6 +145,9 @@ INSPIRE_PARSER_KEYWORDS = {
     'fulltext': 'fulltext',
     'ft': 'fulltext',
 
+    # SPIRES identifiers
+    'irn': 'irn',
+
     # Job related
     'position': 'title',
     'region': 'region',

--- a/inspire_query_parser/visitors/elastic_search_visitor.py
+++ b/inspire_query_parser/visitors/elastic_search_visitor.py
@@ -72,6 +72,7 @@ class ElasticSearchVisitor(Visitor):
         ],
         'doi': 'dois.value.raw',
         'eprint': 'arxiv_eprints.value.raw',
+        'irn': 'external_system_identifiers.value.raw',
         'refersto': 'references.recid',
         'reportnumber': 'report_numbers.value.fuzzy',
         'subject': 'facet_inspire_categories',
@@ -320,6 +321,9 @@ class ElasticSearchVisitor(Visitor):
                             return self.visit_partial_match_value(node, bai_fieldnames)
 
                     return self._generate_author_query(node.value)
+
+                elif ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['irn'] == fieldnames:
+                    return {'term': {fieldnames: ''.join(('SPIRES-', node.value))}}
 
                 return {
                     'match': {

--- a/tests/test_elastic_search_visitor.py
+++ b/tests/test_elastic_search_visitor.py
@@ -99,6 +99,19 @@ def test_elastic_search_visitor_find_author_simple_value_ellis():
     assert generated_es_query == expected_es_query
 
 
+def test_elastic_search_visitor_find_spires_identifier_simple_value():
+    query_str = 'irn 3665763'
+    expected_es_query = \
+        {
+            "term": {
+                "external_system_identifiers.value.raw": "SPIRES-3665763"
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
 def test_elastic_search_visitor_and_op_query():
     author_name = 'Ellis, John'
     name_variations = generate_name_variations(author_name)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I added functionality to the es-visitor that supports `irn` simple value queries,
i.e. for SPIRES identifiers. There is no need to support this kind of query
with partial or exact values, as they are only made by the system and not by users,
always having this expected layout.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/inspirehep/inspire-query-parser/issues/65

## Related PR
https://github.com/inspirehep/inspire-next/pull/3058

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It is needed for the inspire_query_parser to support `irn`(term) queries.
This is supported by Legacy.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Signed-off-by: Iuliana Voinea <iuliana.voinea@student.manchester.ac.uk>