### PR TITLE
es-visitor: check partial BAI on normalized name

### DIFF
--- a/inspire_query_parser/visitors/elastic_search_visitor.py
+++ b/inspire_query_parser/visitors/elastic_search_visitor.py
@@ -32,7 +32,7 @@ import re
 
 from inspire_utils.helpers import force_list
 
-from inspire_utils.name import generate_name_variations
+from inspire_utils.name import generate_name_variations, normalize_name
 from pypeg2 import whitespace
 
 from inspire_query_parser import ast
@@ -110,14 +110,16 @@ class ElasticSearchVisitor(Visitor):
         if bai_field_variation not in (FieldVariations.search, FieldVariations.raw):
             raise ValueError('Non supported field variation "{}".'.format(bai_field_variation))
 
+        normalized_author_name = normalize_name(node_value).strip('.')
+
         if ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['author'] and \
                 ElasticSearchVisitor.BAI_REGEX.match(node_value):
             return [ElasticSearchVisitor.AUTHORS_BAI_FIELD + '.' + bai_field_variation]
 
-        elif not whitespace.search(node_value) and \
+        elif not whitespace.search(normalized_author_name) and \
                 query_bai_field_if_dots_in_name and \
                 ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['author'] and \
-                '.' in node_value:
+                '.' in normalized_author_name:
             # Case of partial BAI, e.g. ``J.Smith``.
             return [ElasticSearchVisitor.AUTHORS_BAI_FIELD + '.' + bai_field_variation] + \
                    force_list(ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['author'])

--- a/tests/test_elastic_search_visitor.py
+++ b/tests/test_elastic_search_visitor.py
@@ -903,6 +903,27 @@ def test_elastic_search_visitor_queries_also_bai_field_with_wildcard_if_author_n
     assert generated_es_query == expected_es_query
 
 
+def test_elastic_search_visitor_queries_does_not_query_bai_field_if_name_contains_comma_and_dot():
+    query_str = 'a gava,e.'
+
+    generated_es_query = _parse_query(query_str)
+    assert ElasticSearchVisitor.AUTHORS_BAI_FIELD not in str(generated_es_query)
+
+
+def test_elastic_search_visitor_queries_does_not_query_bai_field_if_name_contains_trailing_dot():
+    query_str = 'a mele.'
+
+    generated_es_query = _parse_query(query_str)
+    assert ElasticSearchVisitor.AUTHORS_BAI_FIELD not in str(generated_es_query)
+
+
+def test_elastic_search_visitor_queries_does_not_query_bai_field_if_name_contains_prefix_dot():
+    query_str = 'a .mele'
+
+    generated_es_query = _parse_query(query_str)
+    assert ElasticSearchVisitor.AUTHORS_BAI_FIELD not in str(generated_es_query)
+
+
 def test_elastic_search_visitor_does_not_query_bai_field_if_name_contains_dot_and_spaces():
     query_str = 'a S. Mele'
     bai_field = "authors.ids.value.search"


### PR DESCRIPTION
Checking for partial BAI should happen on a normalized author name, so
that we can make the code that detects it simpler, without adding more
special cases (addresses inspirehep/inspire-next#3055).

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>