### PR TITLE
es-visitor: fix date (multi-field) range queries

### DIFF
--- a/inspire_query_parser/parsing_driver.py
+++ b/inspire_query_parser/parsing_driver.py
@@ -54,7 +54,9 @@ def parse_query(query_str):
         query_str argument.
     """
     def _generate_match_all_fields_query():
-        return {'multi_match': {'query': query_str, 'fields': ['_all'], 'zero_terms_query': 'all'}}
+        # Strip colon character (special character for ES)
+        stripped_query_str = ' '.join(query_str.replace(':', ' ').split())
+        return {'multi_match': {'query': stripped_query_str, 'fields': ['_all'], 'zero_terms_query': 'all'}}
 
     if not isinstance(query_str, six.text_type):
         query_str = six.text_type(query_str.decode('utf-8'))

--- a/inspire_query_parser/parsing_driver.py
+++ b/inspire_query_parser/parsing_driver.py
@@ -104,4 +104,8 @@ def parse_query(query_str):
         )
         return _generate_match_all_fields_query()
 
+    if not es_query:
+        # Case where an empty query was generated (i.e. date query with malformed date, e.g. "d < 200").
+        return _generate_match_all_fields_query()
+
     return es_query

--- a/inspire_query_parser/utils/visitor_utils.py
+++ b/inspire_query_parser/utils/visitor_utils.py
@@ -211,9 +211,10 @@ def _get_next_date_from_partial_date(partial_date):
         PartialDate: The next date from the given partial date.
     """
     relativedelta_arg = 'years'
-    if partial_date.month and not partial_date.day:
+
+    if partial_date.month:
         relativedelta_arg = 'months'
-    elif partial_date.month and partial_date.day:
+    if partial_date.day:
         relativedelta_arg = 'days'
 
     next_date = parse(partial_date.dumps()) + relativedelta(**{relativedelta_arg: 1})
@@ -244,10 +245,10 @@ def _get_proper_elastic_search_date_rounding_format(partial_date):
     """
     es_date_math_unit = ES_DATE_MATH_ROUNDING_YEAR
 
-    if partial_date.month and partial_date.day:
-        es_date_math_unit = ES_DATE_MATH_ROUNDING_DAY
-    elif partial_date.month and not partial_date.day:
+    if partial_date.month:
         es_date_math_unit = ES_DATE_MATH_ROUNDING_MONTH
+    if partial_date.day:
+        es_date_math_unit = ES_DATE_MATH_ROUNDING_DAY
 
     return es_date_math_unit
 
@@ -275,7 +276,8 @@ def update_date_value_in_operator_value_pairs_for_fieldname(field, operator_valu
                 modified_date.dumps() + _get_proper_elastic_search_date_rounding_format(modified_date)
 
             next_date = _get_next_date_from_partial_date(modified_date)
-            updated_operator_value_pairs['lt'] = next_date.dumps() + _get_proper_elastic_search_date_rounding_format(next_date)
+            updated_operator_value_pairs['lt'] = \
+                next_date.dumps() + _get_proper_elastic_search_date_rounding_format(next_date)
         else:
             updated_operator_value_pairs[operator] = \
                 modified_date.dumps() + _get_proper_elastic_search_date_rounding_format(modified_date)

--- a/inspire_query_parser/visitors/elastic_search_visitor.py
+++ b/inspire_query_parser/visitors/elastic_search_visitor.py
@@ -40,7 +40,7 @@ from inspire_query_parser.config import (DEFAULT_ES_OPERATOR_FOR_MALFORMED_QUERI
                                          ES_MUST_QUERY)
 from inspire_query_parser.visitors.visitor_impl import Visitor
 from inspire_query_parser.utils.visitor_utils import update_date_value_in_operator_value_pairs_for_fieldname, \
-    ES_RANGE_EQ_OPERATOR
+    ES_RANGE_EQ_OPERATOR, truncate_date_value_according_on_date_field
 
 logger = logging.getLogger(__name__)
 
@@ -388,7 +388,13 @@ class ElasticSearchVisitor(Visitor):
             query_bai_field_if_dots_in_name=False
         )
 
-        term_queries = [{'term': {field: node.value}} for field in (bai_fieldnames or fieldnames)]
+        if ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['date'] == fieldnames:
+            term_queries = [{'term': {field: truncate_date_value_according_on_date_field(field, node.value).dumps()}}
+                            for field
+                            in fieldnames]
+        else:
+            term_queries = [{'term': {field: node.value}} for field in (bai_fieldnames or fieldnames)]
+
         if len(term_queries) > 1:
             return {'bool': {'should': term_queries}}
         else:

--- a/inspire_query_parser/visitors/elastic_search_visitor.py
+++ b/inspire_query_parser/visitors/elastic_search_visitor.py
@@ -402,6 +402,11 @@ class ElasticSearchVisitor(Visitor):
 
     def visit_partial_match_value(self, node, fieldnames=None):
         """Generates a query which looks for a substring of the node's value in the given fieldname."""
+        if ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['date'] == fieldnames:
+            # Date queries with partial values are transformed into range queries, among the given and the exact
+            # next date, according to the granularity of the given date.
+            return self._generate_range_queries(force_list(fieldnames), {ES_RANGE_EQ_OPERATOR: node.value})
+
         # Add wildcard token as prefix and suffix.
         value = \
             ('' if node.value.startswith(ast.GenericValue.WILDCARD_TOKEN) else '*') + \

--- a/tests/test_elastic_search_visitor.py
+++ b/tests/test_elastic_search_visitor.py
@@ -636,7 +636,7 @@ def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_val
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_exact_match_value():
+def test_elastic_search_visitor_with_date_multi_field_and_exact_match_value():
     query_str = 'date "2000-10"'
     expected_es_query = \
         {
@@ -659,7 +659,7 @@ def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_exa
                     },
                     {
                         "term": {
-                            "publication_info.year": "2000-10"
+                            "publication_info.year": "2000"
                         }
                     },
                     {

--- a/tests/test_elastic_search_visitor.py
+++ b/tests/test_elastic_search_visitor.py
@@ -335,11 +335,11 @@ def test_elastic_search_visitor_range_op():
                     {
                         "bool": {
                             "should": [
-                                {"range": {"earliest_date": {"gte": "2015", "lte": "2017"}}},
-                                {"range": {"imprints.date": {"gte": "2015", "lte": "2017"}}},
-                                {"range": {"preprint_date": {"gte": "2015", "lte": "2017"}}},
-                                {"range": {"publication_info.year": {"gte": "2015", "lte": "2017"}}},
-                                {"range": {"thesis_info.date": {"gte": "2015", "lte": "2017"}}},
+                                {"range": {"earliest_date": {"gte": "2015||/y", "lte": "2017||/y"}}},
+                                {"range": {"imprints.date": {"gte": "2015||/y", "lte": "2017||/y"}}},
+                                {"range": {"preprint_date": {"gte": "2015||/y", "lte": "2017||/y"}}},
+                                {"range": {"publication_info.year": {"gte": "2015||/y", "lte": "2017||/y"}}},
+                                {"range": {"thesis_info.date": {"gte": "2015||/y", "lte": "2017||/y"}}},
                             ]
                         }
                     },
@@ -564,11 +564,11 @@ def test_elastic_search_visitor_with_date_multi_field_and_simple_value_handles_o
         {
             "bool": {
                 "should": [
-                    {"range": {"earliest_date": {"gte": "2000-10", "lt": "2000-11"}}},
-                    {"range": {"imprints.date": {"gte": "2000-10", "lt": "2000-11"}}},
-                    {"range": {"preprint_date": {"gte": "2000-10", "lt": "2000-11"}}},
-                    {"range": {"publication_info.year": {"gte": "2000", "lt": "2001"}}},
-                    {"range": {"thesis_info.date": {"gte": "2000-10", "lt": "2000-11"}}},
+                    {"range": {"earliest_date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
+                    {"range": {"imprints.date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
+                    {"range": {"preprint_date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
+                    {"range": {"publication_info.year": {"gte": "2000||/y", "lt": "2001||/y"}}},
+                    {"range": {"thesis_info.date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
                 ]
             }
         }
@@ -583,11 +583,11 @@ def test_elastic_search_visitor_with_date_multi_field_and_simple_value_handles_r
         {
             "bool": {
                 "should": [
-                    {"range": {"earliest_date": {"gte": "2017-12", "lt": "2018-01"}}},
-                    {"range": {"imprints.date": {"gte": "2017-12", "lt": "2018-01"}}},
-                    {"range": {"preprint_date": {"gte": "2017-12", "lt": "2018-01"}}},
-                    {"range": {"publication_info.year": {"gte": "2017", "lt": "2018"}}},
-                    {"range": {"thesis_info.date": {"gte": "2017-12", "lt": "2018-01"}}},
+                    {"range": {"earliest_date": {"gte": "2017-12||/M", "lt": "2018-01||/M"}}},
+                    {"range": {"imprints.date": {"gte": "2017-12||/M", "lt": "2018-01||/M"}}},
+                    {"range": {"preprint_date": {"gte": "2017-12||/M", "lt": "2018-01||/M"}}},
+                    {"range": {"publication_info.year": {"gte": "2017||/y", "lt": "2018||/y"}}},
+                    {"range": {"thesis_info.date": {"gte": "2017-12||/M", "lt": "2018-01||/M"}}},
                 ]
             }
         }
@@ -602,11 +602,11 @@ def test_elastic_search_visitor_with_date_multi_field_and_simple_value_handles_r
         {
             "bool": {
                 "should": [
-                    {"range": {"earliest_date": {"gte": "2017-10-31", "lt": "2017-11-01"}}},
-                    {"range": {"imprints.date": {"gte": "2017-10-31", "lt": "2017-11-01"}}},
-                    {"range": {"preprint_date": {"gte": "2017-10-31", "lt": "2017-11-01"}}},
-                    {"range": {"publication_info.year": {"gte": "2017", "lt": "2018"}}},
-                    {"range": {"thesis_info.date": {"gte": "2017-10-31", "lt": "2017-11-01"}}},
+                    {"range": {"earliest_date": {"gte": "2017-10-31||/d", "lt": "2017-11-01||/d"}}},
+                    {"range": {"imprints.date": {"gte": "2017-10-31||/d", "lt": "2017-11-01||/d"}}},
+                    {"range": {"preprint_date": {"gte": "2017-10-31||/d", "lt": "2017-11-01||/d"}}},
+                    {"range": {"publication_info.year": {"gte": "2017||/y", "lt": "2018||/y"}}},
+                    {"range": {"thesis_info.date": {"gte": "2017-10-31||/d", "lt": "2017-11-01||/d"}}},
                 ]
             }
         }
@@ -621,11 +621,11 @@ def test_elastic_search_visitor_with_date_multi_field_and_wildcard_value_suffix_
         {
             "bool": {
                 "should": [
-                    {"range": {"earliest_date": {"gte": "2000-10", "lt": "2000-11"}}},
-                    {"range": {"imprints.date": {"gte": "2000-10", "lt": "2000-11"}}},
-                    {"range": {"preprint_date": {"gte": "2000-10", "lt": "2000-11"}}},
-                    {"range": {"publication_info.year": {"gte": "2000", "lt": "2001"}}},
-                    {"range": {"thesis_info.date": {"gte": "2000-10", "lt": "2000-11"}}},
+                    {"range": {"earliest_date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
+                    {"range": {"imprints.date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
+                    {"range": {"preprint_date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
+                    {"range": {"publication_info.year": {"gte": "2000||/y", "lt": "2001||/y"}}},
+                    {"range": {"thesis_info.date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
                 ]
             }
         }
@@ -640,11 +640,11 @@ def test_elastic_search_visitor_with_date_multi_field_and_wildcard_value_suffix_
         {
             "bool": {
                 "should": [
-                    {"range": {"earliest_date": {"gte": "2015", "lt": "2016"}}},
-                    {"range": {"imprints.date": {"gte": "2015", "lt": "2016"}}},
-                    {"range": {"preprint_date": {"gte": "2015", "lt": "2016"}}},
-                    {"range": {"publication_info.year": {"gte": "2015", "lt": "2016"}}},
-                    {"range": {"thesis_info.date": {"gte": "2015", "lt": "2016"}}},
+                    {"range": {"earliest_date": {"gte": "2015||/y", "lt": "2016||/y"}}},
+                    {"range": {"imprints.date": {"gte": "2015||/y", "lt": "2016||/y"}}},
+                    {"range": {"preprint_date": {"gte": "2015||/y", "lt": "2016||/y"}}},
+                    {"range": {"publication_info.year": {"gte": "2015||/y", "lt": "2016||/y"}}},
+                    {"range": {"thesis_info.date": {"gte": "2015||/y", "lt": "2016||/y"}}},
                 ]
             }
         }
@@ -659,11 +659,11 @@ def test_elastic_search_visitor_with_date_multi_field_and_wildcard_value_suffix_
         {
             "bool": {
                 "should": [
-                    {"range": {"earliest_date": {"gte": "2015", "lt": "2016"}}},
-                    {"range": {"imprints.date": {"gte": "2015", "lt": "2016"}}},
-                    {"range": {"preprint_date": {"gte": "2015", "lt": "2016"}}},
-                    {"range": {"publication_info.year": {"gte": "2015", "lt": "2016"}}},
-                    {"range": {"thesis_info.date": {"gte": "2015", "lt": "2016"}}},
+                    {"range": {"earliest_date": {"gte": "2015||/y", "lt": "2016||/y"}}},
+                    {"range": {"imprints.date": {"gte": "2015||/y", "lt": "2016||/y"}}},
+                    {"range": {"preprint_date": {"gte": "2015||/y", "lt": "2016||/y"}}},
+                    {"range": {"publication_info.year": {"gte": "2015||/y", "lt": "2016||/y"}}},
+                    {"range": {"thesis_info.date": {"gte": "2015||/y", "lt": "2016||/y"}}},
                 ]
             }
         }
@@ -761,11 +761,11 @@ def test_elastic_search_visitor_with_date_multi_field_and_partial_value():
         {
             "bool": {
                 "should": [
-                    {"range": {"earliest_date": {"gte": "2000-10", "lt": "2000-11"}}},
-                    {"range": {"imprints.date": {"gte": "2000-10", "lt": "2000-11"}}},
-                    {"range": {"preprint_date": {"gte": "2000-10", "lt": "2000-11"}}},
-                    {"range": {"publication_info.year": {"gte": "2000", "lt": "2001"}}},
-                    {"range": {"thesis_info.date": {"gte": "2000-10", "lt": "2000-11"}}},
+                    {"range": {"earliest_date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
+                    {"range": {"imprints.date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
+                    {"range": {"preprint_date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
+                    {"range": {"publication_info.year": {"gte": "2000||/y", "lt": "2001||/y"}}},
+                    {"range": {"thesis_info.date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
                 ]
             }
         }
@@ -780,11 +780,11 @@ def test_elastic_search_visitor_with_date_multi_field_and_partial_value_with_wil
         {
             "bool": {
                 "should": [
-                    {"range": {"earliest_date": {"gte": "2000-10", "lt": "2000-11"}}},
-                    {"range": {"imprints.date": {"gte": "2000-10", "lt": "2000-11"}}},
-                    {"range": {"preprint_date": {"gte": "2000-10", "lt": "2000-11"}}},
-                    {"range": {"publication_info.year": {"gte": "2000", "lt": "2001"}}},
-                    {"range": {"thesis_info.date": {"gte": "2000-10", "lt": "2000-11"}}},
+                    {"range": {"earliest_date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
+                    {"range": {"imprints.date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
+                    {"range": {"preprint_date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
+                    {"range": {"publication_info.year": {"gte": "2000||/y", "lt": "2001||/y"}}},
+                    {"range": {"thesis_info.date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
                 ]
             }
         }
@@ -798,11 +798,11 @@ def test_elastic_search_visitor_with_date_multi_field_and_range_op():
     expected_es_query = {
         "bool": {
             "should": [
-                {"range": {"earliest_date": {"gte": "2000-01", "lte": "2001-01"}}},
-                {"range": {"imprints.date": {"gte": "2000-01", "lte": "2001-01"}}},
-                {"range": {"preprint_date": {"gte": "2000-01", "lte": "2001-01"}}},
-                {"range": {"publication_info.year": {"gte": "2000", "lte": "2001"}}},
-                {"range": {"thesis_info.date": {"gte": "2000-01", "lte": "2001-01"}}},
+                {"range": {"earliest_date": {"gte": "2000-01||/M", "lte": "2001-01||/M"}}},
+                {"range": {"imprints.date": {"gte": "2000-01||/M", "lte": "2001-01||/M"}}},
+                {"range": {"preprint_date": {"gte": "2000-01||/M", "lte": "2001-01||/M"}}},
+                {"range": {"publication_info.year": {"gte": "2000||/y", "lte": "2001||/y"}}},
+                {"range": {"thesis_info.date": {"gte": "2000-01||/M", "lte": "2001-01||/M"}}},
             ]
         }
     }
@@ -818,11 +818,11 @@ def test_elastic_search_visitor_with_date_multi_field_range_within_same_year():
     expected_es_query = {
         "bool": {
             "should": [
-                {"range": {"earliest_date": {"gte": "2000-01", "lte": "2000-04"}}},
-                {"range": {"imprints.date": {"gte": "2000-01", "lte": "2000-04"}}},
-                {"range": {"preprint_date": {"gte": "2000-01", "lte": "2000-04"}}},
-                {"range": {"publication_info.year": {"gte": "2000", "lte": "2000"}}},
-                {"range": {"thesis_info.date": {"gte": "2000-01", "lte": "2000-04"}}},
+                {"range": {"earliest_date": {"gte": "2000-01||/M", "lte": "2000-04||/M"}}},
+                {"range": {"imprints.date": {"gte": "2000-01||/M", "lte": "2000-04||/M"}}},
+                {"range": {"preprint_date": {"gte": "2000-01||/M", "lte": "2000-04||/M"}}},
+                {"range": {"publication_info.year": {"gte": "2000||/y", "lte": "2000||/y"}}},
+                {"range": {"thesis_info.date": {"gte": "2000-01||/M", "lte": "2000-04||/M"}}},
             ]
         }
     }
@@ -848,11 +848,11 @@ def test_elastic_search_visitor_with_date_multi_field_and_gt_op():
                     {
                         "bool": {
                             "should": [
-                                {"range": {"earliest_date": {"gt": "2015"}}},
-                                {"range": {"imprints.date": {"gt": "2015"}}},
-                                {"range": {"preprint_date": {"gt": "2015"}}},
-                                {"range": {"publication_info.year": {"gt": "2015"}}},
-                                {"range": {"thesis_info.date": {"gt": "2015"}}},
+                                {"range": {"earliest_date": {"gt": "2015||/y"}}},
+                                {"range": {"imprints.date": {"gt": "2015||/y"}}},
+                                {"range": {"preprint_date": {"gt": "2015||/y"}}},
+                                {"range": {"publication_info.year": {"gt": "2015||/y"}}},
+                                {"range": {"thesis_info.date": {"gt": "2015||/y"}}},
                             ]
                         }
                     }
@@ -881,11 +881,11 @@ def test_elastic_search_visitor_with_date_multi_field_and_gte_op():
                     {
                         "bool": {
                             "should": [
-                                {"range": {"earliest_date": {"gte": "2015"}}},
-                                {"range": {"imprints.date": {"gte": "2015"}}},
-                                {"range": {"preprint_date": {"gte": "2015"}}},
-                                {"range": {"publication_info.year": {"gte": "2015"}}},
-                                {"range": {"thesis_info.date": {"gte": "2015"}}},
+                                {"range": {"earliest_date": {"gte": "2015||/y"}}},
+                                {"range": {"imprints.date": {"gte": "2015||/y"}}},
+                                {"range": {"preprint_date": {"gte": "2015||/y"}}},
+                                {"range": {"publication_info.year": {"gte": "2015||/y"}}},
+                                {"range": {"thesis_info.date": {"gte": "2015||/y"}}},
                             ]
                         }
                     }
@@ -914,11 +914,11 @@ def test_elastic_search_visitor_with_date_multi_field_and_lt_op():
                     {
                         "bool": {
                             "should": [
-                                {"range": {"earliest_date": {"lt": "2015-08"}}},
-                                {"range": {"imprints.date": {"lt": "2015-08"}}},
-                                {"range": {"preprint_date": {"lt": "2015-08"}}},
-                                {"range": {"publication_info.year": {"lt": "2015"}}},
-                                {"range": {"thesis_info.date": {"lt": "2015-08"}}},
+                                {"range": {"earliest_date": {"lt": "2015-08||/M"}}},
+                                {"range": {"imprints.date": {"lt": "2015-08||/M"}}},
+                                {"range": {"preprint_date": {"lt": "2015-08||/M"}}},
+                                {"range": {"publication_info.year": {"lt": "2015||/y"}}},
+                                {"range": {"thesis_info.date": {"lt": "2015-08||/M"}}},
                             ]
                         }
                     }
@@ -947,11 +947,11 @@ def test_elastic_search_visitor_with_date_multi_field_and_lte_op():
                     {
                         "bool": {
                             "should": [
-                                {"range": {"earliest_date": {"lte": "2015-08-30"}}},
-                                {"range": {"imprints.date": {"lte": "2015-08-30"}}},
-                                {"range": {"preprint_date": {"lte": "2015-08-30"}}},
-                                {"range": {"publication_info.year": {"lte": "2015"}}},
-                                {"range": {"thesis_info.date": {"lte": "2015-08-30"}}},
+                                {"range": {"earliest_date": {"lte": "2015-08-30||/d"}}},
+                                {"range": {"imprints.date": {"lte": "2015-08-30||/d"}}},
+                                {"range": {"preprint_date": {"lte": "2015-08-30||/d"}}},
+                                {"range": {"publication_info.year": {"lte": "2015||/y"}}},
+                                {"range": {"thesis_info.date": {"lte": "2015-08-30||/d"}}},
                             ]
                         }
                     }

--- a/tests/test_elastic_search_visitor.py
+++ b/tests/test_elastic_search_visitor.py
@@ -333,12 +333,14 @@ def test_elastic_search_visitor_range_op():
             "bool": {
                 "must": [
                     {
-                        "range": {
-                            "earliest_date": {"gte": "2015", "lte": "2017"},
-                            "imprints.date": {"gte": "2015", "lte": "2017"},
-                            "preprint_date": {"gte": "2015", "lte": "2017"},
-                            "publication_info.year": {"gte": "2015", "lte": "2017"},
-                            "thesis_info.date": {"gte": "2015", "lte": "2017"},
+                        "bool": {
+                            "should": [
+                                {"range": {"earliest_date": {"gte": "2015", "lte": "2017"}}},
+                                {"range": {"imprints.date": {"gte": "2015", "lte": "2017"}}},
+                                {"range": {"preprint_date": {"gte": "2015", "lte": "2017"}}},
+                                {"range": {"publication_info.year": {"gte": "2015", "lte": "2017"}}},
+                                {"range": {"thesis_info.date": {"gte": "2015", "lte": "2017"}}},
+                            ]
                         }
                     },
                     {
@@ -657,7 +659,7 @@ def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_par
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_partial_match_value_with_wildcard():
+def test_elastic_search_visitor_with_date_multi_field_and_partial_value_with_wildcard():
     query_str = 'date \'2000-10-*\''
     expected_es_query = \
         {
@@ -678,24 +680,44 @@ def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_par
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_range_value():
-    query_str = 'date 2000->2005'
-    expected_es_query = \
-        {
-            "range": {
-                "earliest_date": {"gte": "2000", "lte": "2005"},
-                "imprints.date": {"gte": "2000", "lte": "2005"},
-                "preprint_date": {"gte": "2000", "lte": "2005"},
-                "publication_info.year": {"gte": "2000", "lte": "2005"},
-                "thesis_info.date": {"gte": "2000", "lte": "2005"},
-            }
+def test_elastic_search_visitor_with_date_multi_field_and_range_op():
+    query_str = 'date 2000-01->2001-01'
+    expected_es_query = {
+        "bool": {
+            "should": [
+                {"range": {"earliest_date": {"gte": "2000-01", "lte": "2001-01"}}},
+                {"range": {"imprints.date": {"gte": "2000-01", "lte": "2001-01"}}},
+                {"range": {"preprint_date": {"gte": "2000-01", "lte": "2001-01"}}},
+                {"range": {"publication_info.year": {"gte": "2000", "lte": "2001"}}},
+                {"range": {"thesis_info.date": {"gte": "2000-01", "lte": "2001-01"}}},
+            ]
         }
+    }
 
     generated_es_query = _parse_query(query_str)
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_gt_op():
+def test_elastic_search_visitor_with_date_multi_field_range_within_same_year():
+    # This works fine, since the range operator is including the edges, otherwise it would result in returning nothing.
+    query_str = 'date 2000-01->2000-04'
+    expected_es_query = {
+        "bool": {
+            "should": [
+                {"range": {"earliest_date": {"gte": "2000-01", "lte": "2000-04"}}},
+                {"range": {"imprints.date": {"gte": "2000-01", "lte": "2000-04"}}},
+                {"range": {"preprint_date": {"gte": "2000-01", "lte": "2000-04"}}},
+                {"range": {"publication_info.year": {"gte": "2000", "lte": "2000"}}},
+                {"range": {"thesis_info.date": {"gte": "2000-01", "lte": "2000-04"}}},
+            ]
+        }
+    }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_with_date_multi_field_and_gt_op():
     query_str = 'title γ-radiation and date > 2015'
     expected_es_query = \
         {
@@ -710,12 +732,14 @@ def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_gt_
                         }
                     },
                     {
-                        "range": {
-                            "earliest_date": {"gt": "2015"},
-                            "imprints.date": {"gt": "2015"},
-                            "preprint_date": {"gt": "2015"},
-                            "publication_info.year": {"gt": "2015"},
-                            "thesis_info.date": {"gt": "2015"},
+                        "bool": {
+                            "should": [
+                                {"range": {"earliest_date": {"gt": "2015"}}},
+                                {"range": {"imprints.date": {"gt": "2015"}}},
+                                {"range": {"preprint_date": {"gt": "2015"}}},
+                                {"range": {"publication_info.year": {"gt": "2015"}}},
+                                {"range": {"thesis_info.date": {"gt": "2015"}}},
+                            ]
                         }
                     }
                 ]
@@ -726,7 +750,7 @@ def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_gt_
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_gte_op():
+def test_elastic_search_visitor_with_date_multi_field_and_gte_op():
     query_str = 'title γ-radiation and date 2015+'
     expected_es_query = \
         {
@@ -741,12 +765,14 @@ def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_gte
                         }
                     },
                     {
-                        "range": {
-                            "earliest_date": {"gte": "2015"},
-                            "imprints.date": {"gte": "2015"},
-                            "preprint_date": {"gte": "2015"},
-                            "publication_info.year": {"gte": "2015"},
-                            "thesis_info.date": {"gte": "2015"},
+                        "bool": {
+                            "should": [
+                                {"range": {"earliest_date": {"gte": "2015"}}},
+                                {"range": {"imprints.date": {"gte": "2015"}}},
+                                {"range": {"preprint_date": {"gte": "2015"}}},
+                                {"range": {"publication_info.year": {"gte": "2015"}}},
+                                {"range": {"thesis_info.date": {"gte": "2015"}}},
+                            ]
                         }
                     }
                 ]
@@ -757,8 +783,8 @@ def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_gte
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_lt_op():
-    query_str = 'title γ-radiation and date < 2015'
+def test_elastic_search_visitor_with_date_multi_field_and_lt_op():
+    query_str = 'title γ-radiation and date < 2015-08'
     expected_es_query = \
         {
             "bool": {
@@ -772,12 +798,14 @@ def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_lt_
                         }
                     },
                     {
-                        "range": {
-                            "earliest_date": {"lt": "2015"},
-                            "imprints.date": {"lt": "2015"},
-                            "preprint_date": {"lt": "2015"},
-                            "publication_info.year": {"lt": "2015"},
-                            "thesis_info.date": {"lt": "2015"},
+                        "bool": {
+                            "should": [
+                                {"range": {"earliest_date": {"lt": "2015-08"}}},
+                                {"range": {"imprints.date": {"lt": "2015-08"}}},
+                                {"range": {"preprint_date": {"lt": "2015-08"}}},
+                                {"range": {"publication_info.year": {"lt": "2015"}}},
+                                {"range": {"thesis_info.date": {"lt": "2015-08"}}},
+                            ]
                         }
                     }
                 ]
@@ -788,8 +816,8 @@ def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_lt_
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_lte_op():
-    query_str = 'title γ-radiation and date 2015-'
+def test_elastic_search_visitor_with_date_multi_field_and_lte_op():
+    query_str = 'title γ-radiation and date 2015-08-30-'
     expected_es_query = \
         {
             "bool": {
@@ -803,12 +831,72 @@ def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_lte
                         }
                     },
                     {
-                        "range": {
-                            "earliest_date": {"lte": "2015"},
-                            "imprints.date": {"lte": "2015"},
-                            "preprint_date": {"lte": "2015"},
-                            "publication_info.year": {"lte": "2015"},
-                            "thesis_info.date": {"lte": "2015"},
+                        "bool": {
+                            "should": [
+                                {"range": {"earliest_date": {"lte": "2015-08-30"}}},
+                                {"range": {"imprints.date": {"lte": "2015-08-30"}}},
+                                {"range": {"preprint_date": {"lte": "2015-08-30"}}},
+                                {"range": {"publication_info.year": {"lte": "2015"}}},
+                                {"range": {"thesis_info.date": {"lte": "2015-08-30"}}},
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_with_date_malformed_drops_boolean_query_2nd_part():
+    query_str = 'title γ-radiation and date > 2015_08'
+    expected_es_query = \
+        {
+            "bool": {
+                "must": [
+                    {
+                        "match": {
+                            "titles.full_title": {
+                                "query": "γ-radiation",
+                                "operator": "and",
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_with_date_malformed_drops_boolean_query_both_parts():
+    query_str = 'date > 2015_08 and date < 2016_10'
+    expected_es_query = {}  # Equivalent to match_all query.
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_drops_empty_body_boolean_queries():
+    query_str = 'date > 2015_08 and date < 2016_10 and title γ-radiation'
+    expected_es_query = \
+        {
+            "bool": {
+                "must": [
+                    {
+                        "bool": {
+                            "must": [
+                                {
+                                    "match": {
+                                        "titles.full_title": {
+                                            "query": "γ-radiation",
+                                            "operator": "and",
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     }
                 ]

--- a/tests/test_elastic_search_visitor.py
+++ b/tests/test_elastic_search_visitor.py
@@ -615,20 +615,100 @@ def test_elastic_search_visitor_with_date_multi_field_and_simple_value_handles_r
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_value_has_wildcard():
+def test_elastic_search_visitor_with_date_multi_field_and_wildcard_value_suffix_in_day():
     query_str = 'date 2000-10-*'
     expected_es_query = \
         {
-            "query_string": {
-                "analyze_wildcard": True,
-                "fields": [
-                    "earliest_date",
-                    "imprints.date",
-                    "preprint_date",
-                    "publication_info.year",
-                    "thesis_info.date",
-                ],
-                "query": "2000-10-*",
+            "bool": {
+                "should": [
+                    {"range": {"earliest_date": {"gte": "2000-10", "lt": "2000-11"}}},
+                    {"range": {"imprints.date": {"gte": "2000-10", "lt": "2000-11"}}},
+                    {"range": {"preprint_date": {"gte": "2000-10", "lt": "2000-11"}}},
+                    {"range": {"publication_info.year": {"gte": "2000", "lt": "2001"}}},
+                    {"range": {"thesis_info.date": {"gte": "2000-10", "lt": "2000-11"}}},
+                ]
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_with_date_multi_field_and_wildcard_value_suffix_in_month():
+    query_str = 'date 2015-*'
+    expected_es_query = \
+        {
+            "bool": {
+                "should": [
+                    {"range": {"earliest_date": {"gte": "2015", "lt": "2016"}}},
+                    {"range": {"imprints.date": {"gte": "2015", "lt": "2016"}}},
+                    {"range": {"preprint_date": {"gte": "2015", "lt": "2016"}}},
+                    {"range": {"publication_info.year": {"gte": "2015", "lt": "2016"}}},
+                    {"range": {"thesis_info.date": {"gte": "2015", "lt": "2016"}}},
+                ]
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_with_date_multi_field_and_wildcard_value_suffix_as_month_part():
+    query_str = 'date 2015-1*'
+    expected_es_query = \
+        {
+            "bool": {
+                "should": [
+                    {"range": {"earliest_date": {"gte": "2015", "lt": "2016"}}},
+                    {"range": {"imprints.date": {"gte": "2015", "lt": "2016"}}},
+                    {"range": {"preprint_date": {"gte": "2015", "lt": "2016"}}},
+                    {"range": {"publication_info.year": {"gte": "2015", "lt": "2016"}}},
+                    {"range": {"thesis_info.date": {"gte": "2015", "lt": "2016"}}},
+                ]
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_with_date_multi_field_and_wildcard_value_suffix_in_year_drops_date_query():
+    query_str = 'date 201* and title collider'
+    expected_es_query = \
+        {
+            "bool": {
+                "must": [
+                    {
+                        "match": {
+                            "titles.full_title": {
+                                "query": "collider",
+                                "operator": "and",
+                            }
+                        }
+                    },
+                ]
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_with_date_multi_field_and_wildcard_value_suffix_in_month_drops_date_query():
+    query_str = 'date 2000-*-01 and title collider'
+    expected_es_query = \
+        {
+            "bool": {
+                "must": [
+                    {
+                        "match": {
+                            "titles.full_title": {
+                                "query": "collider",
+                                "operator": "and",
+                            }
+                        }
+                    },
+                ]
             }
         }
 
@@ -675,7 +755,7 @@ def test_elastic_search_visitor_with_date_multi_field_and_exact_match_value():
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_with_date_multi_field_and_partial_match_value():
+def test_elastic_search_visitor_with_date_multi_field_and_partial_value():
     query_str = "date '2000-10'"
     expected_es_query = \
         {
@@ -698,16 +778,14 @@ def test_elastic_search_visitor_with_date_multi_field_and_partial_value_with_wil
     query_str = 'date \'2000-10-*\''
     expected_es_query = \
         {
-            "query_string": {
-                "analyze_wildcard": True,
-                "fields": [
-                    "earliest_date",
-                    "imprints.date",
-                    "preprint_date",
-                    "publication_info.year",
-                    "thesis_info.date",
-                ],
-                "query": "*2000-10-*",
+            "bool": {
+                "should": [
+                    {"range": {"earliest_date": {"gte": "2000-10", "lt": "2000-11"}}},
+                    {"range": {"imprints.date": {"gte": "2000-10", "lt": "2000-11"}}},
+                    {"range": {"preprint_date": {"gte": "2000-10", "lt": "2000-11"}}},
+                    {"range": {"publication_info.year": {"gte": "2000", "lt": "2001"}}},
+                    {"range": {"thesis_info.date": {"gte": "2000-10", "lt": "2000-11"}}},
+                ]
             }
         }
 

--- a/tests/test_elastic_search_visitor.py
+++ b/tests/test_elastic_search_visitor.py
@@ -675,20 +675,18 @@ def test_elastic_search_visitor_with_date_multi_field_and_exact_match_value():
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_partial_match_value():
-    query_str = 'date \'2000-10\''
+def test_elastic_search_visitor_with_date_multi_field_and_partial_match_value():
+    query_str = "date '2000-10'"
     expected_es_query = \
         {
-            "query_string": {
-                "analyze_wildcard": True,
-                "fields": [
-                    "earliest_date",
-                    "imprints.date",
-                    "preprint_date",
-                    "publication_info.year",
-                    "thesis_info.date",
-                ],
-                "query": "*2000-10*",
+            "bool": {
+                "should": [
+                    {"range": {"earliest_date": {"gte": "2000-10", "lt": "2000-11"}}},
+                    {"range": {"imprints.date": {"gte": "2000-10", "lt": "2000-11"}}},
+                    {"range": {"preprint_date": {"gte": "2000-10", "lt": "2000-11"}}},
+                    {"range": {"publication_info.year": {"gte": "2000", "lt": "2001"}}},
+                    {"range": {"thesis_info.date": {"gte": "2000-10", "lt": "2000-11"}}},
+                ]
             }
         }
 

--- a/tests/test_parsing_driver.py
+++ b/tests/test_parsing_driver.py
@@ -126,3 +126,18 @@ def test_driver_with_es_visitor_error(mocked_es_visitor):
     es_query = parse_query(query_str)
 
     assert es_query == expected_es_query
+
+
+def test_driver_with_es_visitor_empty_query_generates_a_query_against_all():
+    query_str = 'd < 200'
+    expected_es_query = {
+        'multi_match': {
+            'query': 'd < 200',
+            'fields': ['_all'],
+            'zero_terms_query': 'all'
+        }
+    }
+
+    es_query = parse_query(query_str)
+
+    assert es_query == expected_es_query

--- a/tests/test_visitor_utils.py
+++ b/tests/test_visitor_utils.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, unicode_literals
+
+from pytest import raises
+
+from inspire_query_parser.utils.visitor_utils import _truncate_wildcard_from_date
+
+from test_utils import parametrize
+
+
+@parametrize({
+    'Wildcard as whole day': {
+        'date': '2018-01-*', 'expected_date': '2018-01'
+    },
+    'Wildcard as part of the day': {
+        'date': '2018-01-1*', 'expected_date': '2018-01'
+    },
+    'Wildcard as whole day (space separated)': {
+        'date': '2018 01 *', 'expected_date': '2018-01'
+    },
+    'Wildcard as part of the day (space separated)': {
+        'date': '2018 01 1*', 'expected_date': '2018-01'
+    },
+
+    'Wildcard as whole month': {
+        'date': '2018-*', 'expected_date': '2018'
+    },
+    'Wildcard as part of the month': {
+        'date': '2018-*', 'expected_date': '2018'
+    },
+    'Wildcard as whole month (space separated)': {
+        'date': '2018 *', 'expected_date': '2018'
+    },
+    'Wildcard as part of the month (space separated)': {
+        'date': '2018 1*', 'expected_date': '2018'
+    },
+})
+def test_truncate_wildcard_from_date_with_wildcard(date, expected_date):
+    assert _truncate_wildcard_from_date(date) == expected_date
+
+
+def test_truncate_wildcard_from_date_throws_on_wildcard_in_year():
+    date = '201*'
+    with raises(ValueError):
+        _truncate_wildcard_from_date(date)
+
+
+def test_truncate_wildcard_from_date_throws_with_unsupported_separator():
+    date = '2018_1*'
+    with raises(ValueError):
+        _truncate_wildcard_from_date(date)


### PR DESCRIPTION
Converts mutli-field range queries to a chain of bool.should clauses
so that if a field doesn't exist in the record the query will still
produce results (closes #73).

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>