### PR TITLE
Add support for journal query

### DIFF
--- a/inspire_query_parser/utils/visitor_utils.py
+++ b/inspire_query_parser/utils/visitor_utils.py
@@ -390,22 +390,15 @@ def generate_match_query(field, value, with_operator_and):
     return {'match': {field: value}}
 
 
-def generate_match_queries(fields, values, with_operator_and=False):
-    """Generates a list of match queries for each of the fieldnames-values pairs.
-
-    Notes:
-        The `with_operator_and` flag signifies whether these queries should be generated along with
-        ``"operator": "and"``, and thus, all of their value tokens must match.
-    """
-    match_queries = []
-    for f, v in zip(fields, values):
-        match_queries.append(generate_match_query(f, v, with_operator_and))
-
-    return match_queries
-
-
 def generate_nested_query(path, queries):
-    # TODO: docstring.
+    """Generates nested query.
+
+    Returns:
+        (dict): The nested query if queries is not falsy, otherwise an empty dict.
+    """
+    if not queries:
+        return {}
+
     return {
         'nested': {
             'path': path,
@@ -416,8 +409,7 @@ def generate_nested_query(path, queries):
 
 def wrap_queries_in_bool_clauses_if_more_than_one(queries,
                                                   use_must_clause,
-                                                  preserve_bool_semantics_if_one_clause=False,
-                                                  minimum_should_match=False):
+                                                  preserve_bool_semantics_if_one_clause=False):
     """Helper for wrapping a list of queries into a bool.{must, should} clause.
 
     Args:

--- a/inspire_query_parser/utils/visitor_utils.py
+++ b/inspire_query_parser/utils/visitor_utils.py
@@ -404,9 +404,20 @@ def generate_match_queries(fields, values, with_operator_and=False):
     return match_queries
 
 
+def generate_nested_query(path, queries):
+    # TODO: docstring.
+    return {
+        'nested': {
+            'path': path,
+            'query': queries
+        }
+    }
+
+
 def wrap_queries_in_bool_clauses_if_more_than_one(queries,
                                                   use_must_clause,
-                                                  preserve_bool_semantics_if_one_clause=False):
+                                                  preserve_bool_semantics_if_one_clause=False,
+                                                  minimum_should_match=False):
     """Helper for wrapping a list of queries into a bool.{must, should} clause.
 
     Args:

--- a/inspire_query_parser/visitors/elastic_search_visitor.py
+++ b/inspire_query_parser/visitors/elastic_search_visitor.py
@@ -688,6 +688,9 @@ class ElasticSearchVisitor(Visitor):
         elif ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['type-code'] == fieldnames[0]:
             return self._generate_type_code_query(node.value)
 
+        elif ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['journal'] == fieldnames:
+            return self._generate_journal_nested_queries(node.value)
+
         bai_fieldnames = self._generate_fieldnames_if_bai_query(
             node.value,
             bai_field_variation=FieldVariations.raw,
@@ -718,6 +721,9 @@ class ElasticSearchVisitor(Visitor):
 
         elif ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['type-code'] == fieldnames:
             return self._generate_type_code_query(node.value)
+
+        elif ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['journal'] == fieldnames:
+            return self._generate_journal_nested_queries(node.value)
 
         # Add wildcard token as prefix and suffix.
         value = \

--- a/inspire_query_parser/visitors/elastic_search_visitor.py
+++ b/inspire_query_parser/visitors/elastic_search_visitor.py
@@ -596,7 +596,6 @@ class ElasticSearchVisitor(Visitor):
             })
 
         return nested_queries[0]
->>>>>>> es-visitor: implement journal nested queries
 
     def visit_empty_query(self, node):
         return {'match_all': {}}

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup_requires = [
 
 install_requires=[
     'inspire-schemas~=57.0,>=57.0.0',
-    'inspire-utils~=2.0,>=2.0.0',
     'pypeg2~=2.0,>=2.15.2',
     'python-dateutil~=2.0,>=2.6.1',
     'six~=1.0,>=1.11.0',

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup_requires = [
 ]
 
 install_requires=[
+    'inspire-schemas~=57.0,>=57.0.0',
     'inspire-utils~=2.0,>=2.0.0',
     'pypeg2~=2.0,>=2.15.2',
     'python-dateutil~=2.0,>=2.6.1',

--- a/tests/test_elastic_search_visitor.py
+++ b/tests/test_elastic_search_visitor.py
@@ -215,11 +215,7 @@ def test_elastic_search_visitor_find_journal_title_simple_value():
         {
             "nested": {
                 "path": "publication_info",
-                "query": {
-                    "bool": {
-                        "must": {"match": {"publication_info.journal_title": "Phys.Lett.B"}}
-                    }
-                }
+                "query": {"match": {"publication_info.journal_title": "Phys.Lett.B"}}
             }
         }
 

--- a/tests/test_elastic_search_visitor.py
+++ b/tests/test_elastic_search_visitor.py
@@ -210,7 +210,25 @@ def test_elastic_search_visitor_find_exact_author_with_bai_partial_value_ellis()
 
 
 def test_elastic_search_visitor_find_journal_title_simple_value():
-    query_str = 'j foo'
+    query_str = 'j Phys.Lett.B'
+    expected_es_query = \
+        {
+            "nested": {
+                "path": "publication_info",
+                "query": {
+                    "bool": {
+                        "must": {"match": {"publication_info.journal_title": "Phys.Lett.B"}}
+                    }
+                }
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_find_journal_title_and_new_style_vol_simple_value():
+    query_str = 'j Phys.Lett.B,351'
     expected_es_query = \
         {
             "nested": {
@@ -218,7 +236,8 @@ def test_elastic_search_visitor_find_journal_title_simple_value():
                 "query": {
                     "bool": {
                         "must": [
-                            {"match": {"publication_info.journal_title": "foo"}}
+                            {"match": {"publication_info.journal_title": "Phys.Lett.B"}},
+                            {"match": {"publication_info.journal_volume": "351"}}
                         ]
                     }
                 }
@@ -229,8 +248,8 @@ def test_elastic_search_visitor_find_journal_title_simple_value():
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_find_journal_title_and_vol_simple_value():
-    query_str = 'j foo,bar'
+def test_elastic_search_visitor_find_journal_title_and_old_style_vol_simple_value():
+    query_str = 'j Phys.Lett.,B351'
     expected_es_query = \
         {
             "nested": {
@@ -238,8 +257,8 @@ def test_elastic_search_visitor_find_journal_title_and_vol_simple_value():
                 "query": {
                     "bool": {
                         "must": [
-                            {"match": {"publication_info.journal_title": "foo"}},
-                            {"match": {"publication_info.journal_volume": "bar"}}
+                            {"match": {"publication_info.journal_title": "Phys.Lett.B"}},
+                            {"match": {"publication_info.journal_volume": "351"}}
                         ]
                     }
                 }
@@ -251,7 +270,7 @@ def test_elastic_search_visitor_find_journal_title_and_vol_simple_value():
 
 
 def test_elastic_search_visitor_find_journal_title_and_vol_and_artid_or_start_page_simple_value():
-    query_str = 'j foo,bar,baz'
+    query_str = 'j Phys.Lett.B,351,123'
     expected_es_query = \
         {
             "bool": {
@@ -264,17 +283,17 @@ def test_elastic_search_visitor_find_journal_title_and_vol_and_artid_or_start_pa
                                     "must": [
                                         {
                                             "match": {
-                                                "publication_info.journal_title": "foo"
+                                                "publication_info.journal_title": "Phys.Lett.B"
                                             }
                                         },
                                         {
                                             "match": {
-                                                "publication_info.journal_volume": "bar"
+                                                "publication_info.journal_volume": "351"
                                             }
                                         },
                                         {
                                             "match": {
-                                                "publication_info.page_start": "baz"
+                                                "publication_info.page_start": "123"
                                             }
                                         }
                                     ]
@@ -290,17 +309,17 @@ def test_elastic_search_visitor_find_journal_title_and_vol_and_artid_or_start_pa
                                     "must": [
                                         {
                                             "match": {
-                                                "publication_info.journal_title": "foo"
+                                                "publication_info.journal_title": "Phys.Lett.B"
                                             }
                                         },
                                         {
                                             "match": {
-                                                "publication_info.journal_volume": "bar"
+                                                "publication_info.journal_volume": "351"
                                             }
                                         },
                                         {
                                             "match": {
-                                                "publication_info.artid": "baz"
+                                                "publication_info.artid": "123"
                                             }
                                         }
                                     ]

--- a/tests/test_elastic_search_visitor.py
+++ b/tests/test_elastic_search_visitor.py
@@ -209,6 +209,113 @@ def test_elastic_search_visitor_find_exact_author_with_bai_partial_value_ellis()
     assert generated_es_query == expected_es_query
 
 
+def test_elastic_search_visitor_find_journal_title_simple_value():
+    query_str = 'j foo'
+    expected_es_query = \
+        {
+            "nested": {
+                "path": "publication_info",
+                "query": {
+                    "bool": {
+                        "must": [
+                            {"match": {"publication_info.journal_title": "foo"}}
+                        ]
+                    }
+                }
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_find_journal_title_and_vol_simple_value():
+    query_str = 'j foo,bar'
+    expected_es_query = \
+        {
+            "nested": {
+                "path": "publication_info",
+                "query": {
+                    "bool": {
+                        "must": [
+                            {"match": {"publication_info.journal_title": "foo"}},
+                            {"match": {"publication_info.journal_volume": "bar"}}
+                        ]
+                    }
+                }
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_find_journal_title_and_vol_and_artid_or_start_page_simple_value():
+    query_str = 'j foo,bar,baz'
+    expected_es_query = \
+        {
+            "bool": {
+                "should": [
+                    {
+                        "nested": {
+                            "path": "publication_info",
+                            "query": {
+                                "bool": {
+                                    "must": [
+                                        {
+                                            "match": {
+                                                "publication_info.journal_title": "foo"
+                                            }
+                                        },
+                                        {
+                                            "match": {
+                                                "publication_info.journal_volume": "bar"
+                                            }
+                                        },
+                                        {
+                                            "match": {
+                                                "publication_info.page_start": "baz"
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "nested": {
+                            "path": "publication_info",
+                            "query": {
+                                "bool": {
+                                    "must": [
+                                        {
+                                            "match": {
+                                                "publication_info.journal_title": "foo"
+                                            }
+                                        },
+                                        {
+                                            "match": {
+                                                "publication_info.journal_volume": "bar"
+                                            }
+                                        },
+                                        {
+                                            "match": {
+                                                "publication_info.artid": "baz"
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
 def test_elastic_search_visitor_and_op_query():
     query_str = 'subject: astrophysics and title:boson'
 

--- a/tests/test_elastic_search_visitor.py
+++ b/tests/test_elastic_search_visitor.py
@@ -312,6 +312,26 @@ def test_elastic_search_visitor_find_journal_title_and_vol_and_artid_or_start_pa
     assert ordered(generated_es_query) == ordered(expected_es_query)
 
 
+def test_elastic_search_visitor_exact_journal_query_is_the_same_as_simple_value():
+    simple_value_query_str = 'j Phys.Lett.B,351,123'
+    exact_value_query_str = 'j "Phys.Lett.B,351,123"'
+
+    generated_simple_value_es_query = _parse_query(simple_value_query_str)
+    generated_exact_value_es_query = _parse_query(exact_value_query_str)
+
+    assert ordered(generated_simple_value_es_query) == ordered(generated_exact_value_es_query)
+
+
+def test_elastic_search_visitor_partial_journal_query_is_the_same_as_simple_value():
+    simple_value_query_str = 'j Phys.Lett.B,351,123'
+    partial_value_query_str = "j 'Phys.Lett.B,351,123'"
+
+    generated_simple_value_es_query = _parse_query(simple_value_query_str)
+    generated_partial_value_es_query = _parse_query(partial_value_query_str)
+
+    assert ordered(generated_simple_value_es_query) == ordered(generated_partial_value_es_query)
+
+
 def test_elastic_search_visitor_and_op_query():
     query_str = 'subject: astrophysics and title:boson'
 

--- a/tests/test_elastic_search_visitor.py
+++ b/tests/test_elastic_search_visitor.py
@@ -309,7 +309,7 @@ def test_elastic_search_visitor_find_journal_title_and_vol_and_artid_or_start_pa
         }
 
     generated_es_query = _parse_query(query_str)
-    assert generated_es_query == expected_es_query
+    assert ordered(generated_es_query) == ordered(expected_es_query)
 
 
 def test_elastic_search_visitor_and_op_query():

--- a/tests/test_elastic_search_visitor.py
+++ b/tests/test_elastic_search_visitor.py
@@ -215,7 +215,9 @@ def test_elastic_search_visitor_find_journal_title_simple_value():
         {
             "nested": {
                 "path": "publication_info",
-                "query": {"match": {"publication_info.journal_title": "Phys.Lett.B"}}
+                "query": {
+                    "match": {"publication_info.journal_title": "Phys.Lett.B"}
+                }
             }
         }
 
@@ -269,48 +271,27 @@ def test_elastic_search_visitor_find_journal_title_and_vol_and_artid_or_start_pa
     query_str = 'j Phys.Lett.B,351,123'
     expected_es_query = \
         {
-            "bool": {
-                "should": [
-                    {
-                        "nested": {
-                            "path": "publication_info",
-                            "query": {
+            "nested": {
+                "path": "publication_info",
+                "query": {
+                    "bool": {
+                        "must": [
+                            {
+                                "match": {
+                                    "publication_info.journal_title": "Phys.Lett.B"
+                                }
+                            },
+                            {
+                                "match": {
+                                    "publication_info.journal_volume": "351"
+                                }
+                            },
+                            {
                                 "bool": {
-                                    "must": [
-                                        {
-                                            "match": {
-                                                "publication_info.journal_title": "Phys.Lett.B"
-                                            }
-                                        },
-                                        {
-                                            "match": {
-                                                "publication_info.journal_volume": "351"
-                                            }
-                                        },
+                                    "should": [
                                         {
                                             "match": {
                                                 "publication_info.page_start": "123"
-                                            }
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "nested": {
-                            "path": "publication_info",
-                            "query": {
-                                "bool": {
-                                    "must": [
-                                        {
-                                            "match": {
-                                                "publication_info.journal_title": "Phys.Lett.B"
-                                            }
-                                        },
-                                        {
-                                            "match": {
-                                                "publication_info.journal_volume": "351"
                                             }
                                         },
                                         {
@@ -321,9 +302,9 @@ def test_elastic_search_visitor_find_journal_title_and_vol_and_artid_or_start_pa
                                     ]
                                 }
                             }
-                        }
+                        ]
                     }
-                ]
+                }
             }
         }
 
@@ -412,7 +393,7 @@ def test_elastic_search_visitor_dotted_keyword_simple_value():
     expected_es_query = {
         "match": {
             "dotted.keyword": {
-                "query":  "bar",
+                "query": "bar",
                 "operator": "and",
             }
         }

--- a/tests/test_restructuring_visitor.py
+++ b/tests/test_restructuring_visitor.py
@@ -260,10 +260,7 @@ from inspire_query_parser.visitors.restructuring_visitor import \
         (
             'find (j phys.rev. and vol d85) or (j phys.rev.lett.,62,1825)',
             OrOp(
-                AndOp(
-                    KeywordOp(Keyword('journal'), Value('phys.rev.')),
-                    KeywordOp(Keyword('volume'), Value('d85'))
-                ),
+                KeywordOp(Keyword('journal'), Value('phys.rev.,d85')),
                 KeywordOp(Keyword('journal'), Value('phys.rev.lett.,62,1825'))
             )
          ),
@@ -485,7 +482,74 @@ from inspire_query_parser.visitors.restructuring_visitor import \
                 KeywordOp(Keyword('title'), Value('γ-radiation')),
                 MalformedQuery(['and', 'and'])
             )
-         )
+         ),
+        ('find j Nucl.Phys.,A531,11', KeywordOp(Keyword('journal'), Value('Nucl.Phys.,A531,11'))),
+        (
+            'find j Nucl.Phys. and j Nucl.Phys.',
+            AndOp(
+                KeywordOp(Keyword('journal'), Value('Nucl.Phys.')),
+                KeywordOp(Keyword('journal'), Value('Nucl.Phys.'))
+            )
+        ),
+        (
+            'find j Nucl.Phys. and vol A351 and author ellis',
+            AndOp(
+                KeywordOp(Keyword('journal'), Value('Nucl.Phys.,A351')),
+                KeywordOp(Keyword('author'), Value('ellis'))
+            )
+        ),
+        (
+            'find j Nucl.Phys. and vol A351 and author ellis and author smith and ea john',
+            AndOp(
+                KeywordOp(Keyword('journal'), Value('Nucl.Phys.,A351')),
+                AndOp(
+                    KeywordOp(Keyword('author'), Value('ellis')),
+                    AndOp(
+                        KeywordOp(Keyword('author'), Value('smith')),
+                        KeywordOp(Keyword('exact-author'), Value('john'))
+                    )
+                )
+            )
+        ),
+        ('find j Nucl.Phys. and vol A531', KeywordOp(Keyword('journal'), Value('Nucl.Phys.,A531'))),
+        (
+            'find j Nucl.Phys. and author ellis',
+            AndOp(
+                KeywordOp(Keyword('journal'), Value('Nucl.Phys.')),
+                KeywordOp(Keyword('author'), Value('ellis'))
+            )
+        ),
+        (
+            'find author ellis and j Nucl.Phys. and vol B351 and title Collider',
+            AndOp(
+                KeywordOp(Keyword('author'), Value('ellis')),
+                AndOp(
+                    KeywordOp(Keyword('journal'), Value('Nucl.Phys.,B351')),
+                    KeywordOp(Keyword('title'), Value('Collider'))
+                )
+            )
+        ),
+        (
+            'find author ellis and j Nucl.Phys. and vol B351 and title Collider',
+            AndOp(
+                KeywordOp(Keyword('author'), Value('ellis')),
+                AndOp(
+                    KeywordOp(Keyword('journal'), Value('Nucl.Phys.,B351')),
+                    KeywordOp(Keyword('title'), Value('Collider'))
+                )
+            )
+        ),
+        ('find j Nucl.Phys. and not vol A531', KeywordOp(Keyword('journal'), Value('Nucl.Phys.'))),
+        (
+            'find j Nucl.Phys. and not vol A531 and a ellis and a john',
+            AndOp(
+                KeywordOp(Keyword('journal'), Value('Nucl.Phys.')),
+                AndOp(
+                    KeywordOp(Keyword('author'), Value('ellis')),
+                    KeywordOp(Keyword('author'), Value('john'))
+                )
+            )
+        )
     ]
 )
 def test_restructuring_visitor_functionality(query_str, expected_parse_tree):
@@ -494,6 +558,19 @@ def test_restructuring_visitor_functionality(query_str, expected_parse_tree):
     restructuring_visitor = RestructuringVisitor()
     _, parse_tree = stateful_parser.parse(query_str, parser.Query)
     parse_tree = parse_tree.accept(restructuring_visitor)
+
+    assert parse_tree == expected_parse_tree
+
+
+def test_foo_bar():
+    query_str = 'find j Nucl.Phys. and not vol A531 and a ellis'
+    print("Parsing: " + query_str)
+    stateful_parser = StatefulParser()
+    restructuring_visitor = RestructuringVisitor()
+    _, parse_tree = stateful_parser.parse(query_str, parser.Query)
+    parse_tree = parse_tree.accept(restructuring_visitor)
+    expected_parse_tree = AndOp(KeywordOp(Keyword('journal'), Value('Nucl.Phys.')),
+                                KeywordOp(Keyword('author'), Value('ellis')))
 
     assert parse_tree == expected_parse_tree
 

--- a/tests/test_visitor_utils.py
+++ b/tests/test_visitor_utils.py
@@ -28,7 +28,7 @@ from inspire_query_parser.utils.visitor_utils import (
     _truncate_wildcard_from_date,
     author_name_contains_fullnames,
     generate_minimal_name_variations,
-)
+    generate_match_query, generate_match_queries, wrap_queries_in_bool_clauses_if_more_than_one)
 
 from test_utils import parametrize
 
@@ -169,3 +169,150 @@ def test_truncate_wildcard_from_date_throws_with_unsupported_separator():
     date = '2018_1*'
     with raises(ValueError):
         _truncate_wildcard_from_date(date)
+
+
+def test_generate_match_query_with_bool_value():
+    generated_match_query = generate_match_query('core', True, with_operator_and=True)
+
+    expected_match_query = {
+        'match': {
+            'core': True
+        }
+    }
+
+    assert generated_match_query == expected_match_query
+
+
+def test_generate_match_query_with_operator_and():
+    generated_match_query = generate_match_query('author', 'Ellis, John', with_operator_and=True)
+
+    expected_match_query = {
+        'match': {
+            'author': {
+                'query': 'Ellis, John',
+                'operator': 'and',
+            }
+        }
+    }
+
+    assert generated_match_query == expected_match_query
+
+
+def test_generate_match_query_with_operator_and_false():
+    generated_match_query = generate_match_query('document_type', 'book', with_operator_and=False)
+
+    expected_match_query = {
+        'match': {
+            'document_type': 'book'
+        }
+    }
+
+    assert generated_match_query == expected_match_query
+
+
+def test_generate_match_queries():
+    fields = [
+        'publication_info.journal_title',
+        'publication_info.journal_volume',
+        'publication_info.page_start'
+    ]
+    values = [
+        'Phys.Rev.B',
+        '85',
+        '1051'
+    ]
+
+    generated_match_queries = generate_match_queries(fields, values, with_operator_and=False)
+
+    expected_match_queries = [
+        {'match': {'publication_info.journal_title': 'Phys.Rev.B'}},
+        {'match': {'publication_info.journal_volume': '85'}},
+        {'match': {'publication_info.page_start': '1051'}},
+    ]
+
+    assert generated_match_queries == expected_match_queries
+
+
+def test_wrap_queries_in_bool_clauses_if_more_than_one_with_two_queries():
+    queries = [
+        {'match': {'title': 'collider'}},
+        {'match': {'subject': 'hep'}},
+    ]
+
+    generated_bool_clause = wrap_queries_in_bool_clauses_if_more_than_one(queries,
+                                                                          use_must_clause=True)
+
+    expected_bool_clause = {
+        'bool': {
+            'must': [
+                {'match': {'title': 'collider'}},
+                {'match': {'subject': 'hep'}},
+            ]
+        }
+    }
+
+    assert generated_bool_clause == expected_bool_clause
+
+
+def test_wrap_queries_in_bool_clauses_if_more_than_one_with_one_query_drops_bool_clause_with_flag_disabled():
+    queries = [
+        {'match': {'title': 'collider'}},
+    ]
+
+    generated_bool_clause = wrap_queries_in_bool_clauses_if_more_than_one(queries,
+                                                                          use_must_clause=True)
+
+    expected_bool_clause = {'match': {'title': 'collider'}}
+
+    assert generated_bool_clause == expected_bool_clause
+
+
+def test_wrap_queries_in_bool_clauses_if_more_than_one_with_one_query_preserves_bool_clause_with_flag_enabled():
+    queries = [
+        {'match': {'title': 'collider'}},
+    ]
+
+    generated_bool_clause = wrap_queries_in_bool_clauses_if_more_than_one(queries,
+                                                                          use_must_clause=True,
+                                                                          preserve_bool_semantics_if_one_clause=True)
+
+    expected_bool_clause = {
+        'bool': {
+            'must': [
+                {'match': {'title': 'collider'}}
+            ]
+        }
+    }
+
+    assert generated_bool_clause == expected_bool_clause
+
+
+def test_wrap_queries_in_bool_clauses_if_more_than_one_with_no_query_returns_empty_dict():
+    queries = []
+
+    generated_bool_clause = wrap_queries_in_bool_clauses_if_more_than_one(queries,
+                                                                          use_must_clause=True)
+
+    expected_bool_clause = {}
+
+    assert generated_bool_clause == expected_bool_clause
+
+
+def test_wrap_queries_in_bool_clauses_if_more_than_one_with_one_query_generates_should_clause():
+    queries = [
+        {'match': {'title': 'collider'}},
+    ]
+
+    generated_bool_clause = wrap_queries_in_bool_clauses_if_more_than_one(queries,
+                                                                          use_must_clause=False,
+                                                                          preserve_bool_semantics_if_one_clause=True)
+
+    expected_bool_clause = {
+        'bool': {
+            'should': [
+                {'match': {'title': 'collider'}},
+            ]
+        }
+    }
+
+    assert generated_bool_clause == expected_bool_clause


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Implemented support for `journal` queries and `journal + (not) vol` queries on nested fields in `publication_info`. The value searched for can be comprised of journal_title, journal_volume and artid/page_start in this order, separated by a comma. The value must contain at least the journal_title.
e.g. `find j Nucl.Phys.A, 351, 111` or `find j Nucl.Phys, A351, 111` or `find j Nucl.Phys.A and vol 351`
   
Queries like `find j Nucl.Phys.A and not vol 351` are not supported, so the actual behavior will be that of `find j Nucl.Phys.A`. 

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We are required to support journal queries the same way legacy does.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
