### PR TITLE
es-visitor: rewrite date queries

### DIFF
--- a/inspire_query_parser/parsing_driver.py
+++ b/inspire_query_parser/parsing_driver.py
@@ -54,7 +54,9 @@ def parse_query(query_str):
         query_str argument.
     """
     def _generate_match_all_fields_query():
-        return {'multi_match': {'query': query_str, 'fields': ['_all'], 'zero_terms_query': 'all'}}
+        # Strip colon character (special character for ES)
+        stripped_query_str = ' '.join(query_str.replace(':', ' ').split())
+        return {'multi_match': {'query': stripped_query_str, 'fields': ['_all'], 'zero_terms_query': 'all'}}
 
     if not isinstance(query_str, six.text_type):
         query_str = six.text_type(query_str.decode('utf-8'))
@@ -102,6 +104,10 @@ def parse_query(query_str):
         logger.exception(
             ElasticSearchVisitor.__name__ + " crashed" + (": " + six.text_type(e) + ".") if six.text_type(e) else '.'
         )
+        return _generate_match_all_fields_query()
+
+    if not es_query:
+        # Case where an empty query was generated (i.e. date query with malformed date, e.g. "d < 200").
         return _generate_match_all_fields_query()
 
     return es_query

--- a/inspire_query_parser/utils/visitor_utils.py
+++ b/inspire_query_parser/utils/visitor_utils.py
@@ -24,8 +24,12 @@ from __future__ import absolute_import, unicode_literals
 
 from datetime import date
 from dateutil.relativedelta import relativedelta
+from dateutil.parser import parse
 import re
 
+from inspire_utils.date import PartialDate
+
+from inspire_query_parser.ast import GenericValue
 from inspire_query_parser.config import (DATE_LAST_MONTH_REGEX_PATTERN,
                                          DATE_SPECIFIERS_COLLECTION,
                                          DATE_THIS_MONTH_REGEX_PATTERN,
@@ -34,6 +38,12 @@ from inspire_query_parser.config import (DATE_LAST_MONTH_REGEX_PATTERN,
 
 # #### Date specifiers related utils ####
 ANY_PREFIX_AND_A_NUMBER = re.compile('(.+)(\d+)')
+
+# ES query constants that provide rounding of dates on query time, according to the date "resolution" the user gave.
+# More here: https://www.elastic.co/guide/en/elasticsearch/reference/6.1/common-options.html#date-math
+ES_DATE_MATH_ROUNDING_YEAR = "||/y"
+ES_DATE_MATH_ROUNDING_MONTH = "||/M"
+ES_DATE_MATH_ROUNDING_DAY = "||/d"
 
 
 def _compile_date_regexes(date_specifier_patterns):
@@ -123,3 +133,152 @@ def convert_last_month_date(relative_date_specifier_suffix):
     )
 
     return _convert_date_to_string(start_date, relative_delta)
+
+
+ES_MAPPING_HEP_DATE_ONLY_YEAR = {
+    'publication_info.year',
+}
+"""Contains all the dates that contain always only a year date."""
+
+ES_RANGE_EQ_OPERATOR = 'eq'
+"""Additional (internal to the parser) range operator, for handling date equality queries as ranges."""
+
+
+def _truncate_wildcard_from_date(date_value):
+    """Truncate wildcard from date parts.
+
+    Returns:
+        (str) The truncated date.
+
+    Raises:
+        ValueError, on either unsupported date separator (currently only ' ' and '-' are supported), or if there's a
+        wildcard in the year.
+
+    Notes:
+        Either whole date part is wildcard, in which we ignore it and do a range query on the
+        remaining parts, or some numbers are wildcards, where again, we ignore this part.
+    """
+    if ' ' in date_value:
+        date_parts = date_value.split(' ')
+    elif '-' in date_value:
+        date_parts = date_value.split('-')
+    else:
+        # Either unsupported separators or wildcard in year, e.g. '201*'.
+        raise ValueError("Erroneous date value: %s.", date_value)
+
+    if GenericValue.WILDCARD_TOKEN in date_parts[-1]:
+        del date_parts[-1]
+
+    return '-'.join(date_parts)
+
+
+def _truncate_date_value_according_on_date_field(field, date_value):
+    """Truncates date value (to year only) according to the given date field.
+
+    Args:
+        field (unicode): The field for which the date value will be used to query on.
+        date_value (str): The date value that is going to be truncated to its year.
+
+    Returns:
+        PartialDate: The possibly truncated date, on success. None, otherwise.
+
+    Notes:
+        In case the fieldname is in `ES_MAPPING_HEP_DATE_ONLY_YEAR`, then the date is normalized and then only its year
+        value is used. This is needed for ElasticSearch to be able to do comparisons on dates that have only year, which
+        fails if being queried with a date with more .
+    """
+    try:
+        partial_date = PartialDate.parse(date_value)
+    except ValueError:
+        return None
+
+    if field in ES_MAPPING_HEP_DATE_ONLY_YEAR:
+        truncated_date = PartialDate.from_parts(partial_date.year)
+    else:
+        truncated_date = partial_date
+
+    return truncated_date
+
+
+def _get_next_date_from_partial_date(partial_date):
+    """Calculates the next date from the given partial date.
+
+    Args:
+        partial_date (inspire_utils.date.PartialDate): The partial date whose next date should be calculated.
+
+    Returns:
+        PartialDate: The next date from the given partial date.
+    """
+    relativedelta_arg = 'years'
+
+    if partial_date.month:
+        relativedelta_arg = 'months'
+    if partial_date.day:
+        relativedelta_arg = 'days'
+
+    next_date = parse(partial_date.dumps()) + relativedelta(**{relativedelta_arg: 1})
+    return PartialDate.from_parts(
+        next_date.year,
+        next_date.month if partial_date.month else None,
+        next_date.day if partial_date.day else None
+    )
+
+
+def _get_proper_elastic_search_date_rounding_format(partial_date):
+    """Returns the proper ES date math unit according to the "resolution" of the partial_date.
+
+    Args:
+        partial_date (PartialDate): The partial date for which the date math unit is.
+
+    Returns:
+        (str): The ES date math unit format.
+
+    Notes:
+        This is needed for supporting range queries on dates, i.e. rounding them up or down according to
+        the ES range operator.
+        For example, without this, a query like 'date > 2010-11', would return documents with date '2010-11-15', due to
+        the date value of the query being interpreted by ES as '2010-11-01 01:00:00'. By using the suffixes for rounding
+        up or down, the date value of the query is interpreted as '2010-11-30T23:59:59.999', thus not returning the
+        document with date '2010-11-15', as the user would expect. See:
+        https://www.elastic.co/guide/en/elasticsearch/reference/6.1/query-dsl-range-query.html#_date_math_and_rounding
+    """
+    es_date_math_unit = ES_DATE_MATH_ROUNDING_YEAR
+
+    if partial_date.month:
+        es_date_math_unit = ES_DATE_MATH_ROUNDING_MONTH
+    if partial_date.day:
+        es_date_math_unit = ES_DATE_MATH_ROUNDING_DAY
+
+    return es_date_math_unit
+
+
+def update_date_value_in_operator_value_pairs_for_fieldname(field, operator_value_pairs):
+    """Updates (operator, date value) pairs by normalizing the date value according to the given field.
+
+    Args:
+        field (unicode): The fieldname for which the operator-value pairs are being generated.
+        operator_value_pairs (dict): ES range operator {'gt', 'gte', 'lt', 'lte'} along with a value.
+            Additionally, if the operator is ``ES_RANGE_EQ_OPERATOR``, then it is indicated that the method should
+            generate both a lower and an upper bound operator-value pairs, with the given date_value.
+
+    Notes:
+        On a ``ValueError`` an empty operator_value_pairs is returned.
+    """
+    updated_operator_value_pairs = {}
+    for operator, value in operator_value_pairs.items():
+        modified_date = _truncate_date_value_according_on_date_field(field, value)
+        if not modified_date:
+            return {}
+
+        if operator == ES_RANGE_EQ_OPERATOR:
+            updated_operator_value_pairs['gte'] = \
+                modified_date.dumps() + _get_proper_elastic_search_date_rounding_format(modified_date)
+
+            next_date = _get_next_date_from_partial_date(modified_date)
+            updated_operator_value_pairs['lt'] = \
+                next_date.dumps() + _get_proper_elastic_search_date_rounding_format(next_date)
+        else:
+            updated_operator_value_pairs[operator] = \
+                modified_date.dumps() + _get_proper_elastic_search_date_rounding_format(modified_date)
+
+    return updated_operator_value_pairs

--- a/inspire_query_parser/visitors/elastic_search_visitor.py
+++ b/inspire_query_parser/visitors/elastic_search_visitor.py
@@ -31,6 +31,7 @@ import logging
 import re
 from unicodedata import normalize
 
+import six
 from inspire_utils.helpers import force_list
 
 from inspire_utils.name import (
@@ -41,9 +42,16 @@ from inspire_utils.name import (
 from pypeg2 import whitespace
 
 from inspire_query_parser import ast
+from inspire_query_parser.ast import GenericValue
 from inspire_query_parser.config import (DEFAULT_ES_OPERATOR_FOR_MALFORMED_QUERIES,
                                          ES_MUST_QUERY)
 from inspire_query_parser.visitors.visitor_impl import Visitor
+from inspire_query_parser.utils.visitor_utils import (
+    update_date_value_in_operator_value_pairs_for_fieldname,
+    ES_RANGE_EQ_OPERATOR,
+    _truncate_date_value_according_on_date_field,
+    _truncate_wildcard_from_date
+)
 
 logger = logging.getLogger(__name__)
 
@@ -185,7 +193,28 @@ class ElasticSearchVisitor(Visitor):
                 author_name
             )
 
-    # TODO: move helper method to a utils module.
+    def _generate_date_with_wildcard_query(self, date_value):
+        """Helper for generating a date keyword query containing a wildcard.
+
+        Returns:
+            (dict): The date query containing the wildcard or an empty dict in case the date value is malformed.
+
+        The policy followed here is quite conservative on what it accepts as valid input. Look into
+        :meth:`inspire_query_parser.utils.visitor_utils._truncate_wildcard_from_date` for more information.
+        """
+        if date_value.endswith(GenericValue.WILDCARD_TOKEN):
+            try:
+                date_value = _truncate_wildcard_from_date(date_value)
+            except ValueError:
+                # Drop date query.
+                return {}
+
+            return self._generate_range_queries(self.KEYWORD_TO_ES_FIELDNAME['date'],
+                                                {ES_RANGE_EQ_OPERATOR: date_value})
+        else:
+            # Drop date query with wildcard not as suffix, e.g. 2000-1*-31
+            return {}
+
     def _generate_query_string_query(self, value, fieldnames, analyze_wildcard):
         if not fieldnames:
             field_specifier, field_specifier_value = 'default_field', '_all'
@@ -216,18 +245,18 @@ class ElasticSearchVisitor(Visitor):
         condition_a = node.left.accept(self)
         condition_b = node.right.accept(self)
 
+        bool_body = [condition for condition in [condition_a, condition_b] if condition]
+        if not bool_body:
+            return {}
         return \
             {
                 'bool': {
-                    ('must' if isinstance(node, ast.AndOp) else 'should'): [
-                        condition_a,
-                        condition_b
-                    ]
+                    ('must' if isinstance(node, ast.AndOp) else 'should'): bool_body
                 }
             }
 
     def _generate_range_queries(self, fieldnames, operator_value_pairs):
-        """Generates ElasticSearch range query.
+        """Generates ElasticSearch range queries.
 
         Args:
             fieldnames (list): The fieldnames on which the search is the range query is targeted on,
@@ -236,13 +265,66 @@ class ElasticSearchVisitor(Visitor):
                 The value should be of type int or string.
 
         Notes:
-            If the value type is not compatible, a warning is logged and the value is converted to string.
+            A bool should query with multiple range sub-queries is generated so that even if one of the multiple fields
+            is missing from a document, ElasticSearch will be able to match some records.
+
+            In the case of a 'date' keyword query, it updates date values after normalizing them by using
+            :meth:`inspire_query_parser.utils.visitor_utils.update_date_value_in_operator_value_pairs_for_fieldname`.
+            Additionally, in the aforementioned case, if a malformed date has been given, then the the method will
+            return an empty dictionary.
         """
+
+        if ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['date'] == fieldnames:
+            range_queries = []
+            for fieldname in fieldnames:
+                updated_operator_value_pairs = \
+                    update_date_value_in_operator_value_pairs_for_fieldname(fieldname, operator_value_pairs)
+
+                if not updated_operator_value_pairs:
+                    break  # Malformed date
+                else:
+                    range_queries.append({
+                        'range': {
+                            fieldname: updated_operator_value_pairs
+                        }
+                    })
+        else:
+            range_queries = [{
+                    'range': {
+                        fieldname: operator_value_pairs
+                    }
+                }
+                for fieldname in fieldnames
+            ]
+
+        if len(range_queries) == 0:
+            return {}
+        if len(range_queries) == 1:
+            return range_queries[0]
+
+        return {'bool': {'should': range_queries}}
+
+    @staticmethod
+    def _generate_malformed_query(data):
+        """Generates a query on the ``_all`` field with all the query content.
+
+        Args:
+            data (six.text_type or list): The query in the format of ``six.text_type`` (when used from parsing driver)
+                or ``list`` when used from withing the ES visitor.
+        """
+        if isinstance(data, six.text_type):
+            # Remove colon character (special character for ES)
+            query_str = data.replace(':', ' ')
+        else:
+            query_str = ' '.join([word.strip(':') for word in data.children])
+
         return {
-            'range': {
-                fieldname: operator_value_pairs for fieldname in fieldnames
+            'query_string': {
+                'default_field': '_all',
+                'query': query_str
             }
         }
+
     # ################
 
     def visit_empty_query(self, node):
@@ -259,12 +341,7 @@ class ElasticSearchVisitor(Visitor):
         }
 
     def visit_malformed_query(self, node):
-        return {
-            'query_string': {
-                'default_field': '_all',
-                'query': ' '.join([word.strip(':') for word in node.children])
-            }
-        }
+        return ElasticSearchVisitor._generate_malformed_query(node)
 
     def visit_query_with_malformed_part(self, node):
         query = {
@@ -328,6 +405,9 @@ class ElasticSearchVisitor(Visitor):
             fieldnames = '_all'
 
         if node.contains_wildcard:
+            if ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['date'] == fieldnames:
+                return self._generate_date_with_wildcard_query(node.value)
+
             bai_fieldnames = self._generate_fieldnames_if_bai_query(
                 node.value,
                 bai_field_variation=FieldVariations.search,
@@ -339,6 +419,11 @@ class ElasticSearchVisitor(Visitor):
                                                      analyze_wildcard=True)
         else:
             if isinstance(fieldnames, list):
+                if ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['date'] == fieldnames:
+                    # Date queries with simple values are transformed into range queries, among the given and the exact
+                    # next date, according to the granularity of the given date.
+                    return self._generate_range_queries(force_list(fieldnames), {ES_RANGE_EQ_OPERATOR: node.value})
+
                 return {
                     'multi_match': {
                         'fields': fieldnames,
@@ -393,7 +478,12 @@ class ElasticSearchVisitor(Visitor):
             query_bai_field_if_dots_in_name=False
         )
 
-        term_queries = [{'term': {field: node.value}} for field in (bai_fieldnames or fieldnames)]
+        if ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['date'] == fieldnames:
+            term_queries = [{'term': {field: _truncate_date_value_according_on_date_field(field, node.value).dumps()}}
+                            for field
+                            in fieldnames]
+        else:
+            term_queries = [{'term': {field: node.value}} for field in (bai_fieldnames or fieldnames)]
 
         if len(term_queries) > 1:
             return {'bool': {'should': term_queries}}
@@ -402,6 +492,14 @@ class ElasticSearchVisitor(Visitor):
 
     def visit_partial_match_value(self, node, fieldnames=None):
         """Generates a query which looks for a substring of the node's value in the given fieldname."""
+        if ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['date'] == fieldnames:
+            # Date queries with partial values are transformed into range queries, among the given and the exact
+            # next date, according to the granularity of the given date.
+            if node.contains_wildcard:
+                return self._generate_date_with_wildcard_query(node.value)
+
+            return self._generate_range_queries(force_list(fieldnames), {ES_RANGE_EQ_OPERATOR: node.value})
+
         if ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['exact-author'] == fieldnames:
             return self._generate_exact_author_query(node.value)
 

--- a/tests/test_elastic_search_visitor.py
+++ b/tests/test_elastic_search_visitor.py
@@ -27,7 +27,7 @@ import mock
 
 from inspire_utils.name import generate_name_variations
 
-from inspire_query_parser import parser
+from inspire_query_parser import parser, parse_query
 from inspire_query_parser.config import ES_MUST_QUERY, ES_SHOULD_QUERY
 from inspire_query_parser.stateful_pypeg_parser import StatefulParser
 from inspire_query_parser.visitors.elastic_search_visitor import \
@@ -450,12 +450,14 @@ def test_elastic_search_visitor_range_op():
             "bool": {
                 "must": [
                     {
-                        "range": {
-                            "earliest_date": {"gte": "2015", "lte": "2017"},
-                            "imprints.date": {"gte": "2015", "lte": "2017"},
-                            "preprint_date": {"gte": "2015", "lte": "2017"},
-                            "publication_info.year": {"gte": "2015", "lte": "2017"},
-                            "thesis_info.date": {"gte": "2015", "lte": "2017"},
+                        "bool": {
+                            "should": [
+                                {"range": {"earliest_date": {"gte": "2015||/y", "lte": "2017||/y"}}},
+                                {"range": {"imprints.date": {"gte": "2015||/y", "lte": "2017||/y"}}},
+                                {"range": {"preprint_date": {"gte": "2015||/y", "lte": "2017||/y"}}},
+                                {"range": {"publication_info.year": {"gte": "2015||/y", "lte": "2017||/y"}}},
+                                {"range": {"thesis_info.date": {"gte": "2015||/y", "lte": "2017||/y"}}},
+                            ]
                         }
                     },
                     {
@@ -673,19 +675,18 @@ def test_elastic_search_visitor_with_query_with_malformed_part_and_default_malfo
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_simple_value():
+def test_elastic_search_visitor_with_date_multi_field_and_simple_value_handles_only_year_fields():
     query_str = 'date 2000-10'
     expected_es_query = \
         {
-            "multi_match": {
-                "fields": [
-                    "earliest_date",
-                    "imprints.date",
-                    "preprint_date",
-                    "publication_info.year",
-                    "thesis_info.date",
-                ],
-                "query": "2000-10",
+            "bool": {
+                "should": [
+                    {"range": {"earliest_date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
+                    {"range": {"imprints.date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
+                    {"range": {"preprint_date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
+                    {"range": {"publication_info.year": {"gte": "2000||/y", "lt": "2001||/y"}}},
+                    {"range": {"thesis_info.date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
+                ]
             }
         }
 
@@ -693,20 +694,56 @@ def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_sim
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_value_has_wildcard():
+def test_elastic_search_visitor_with_date_multi_field_and_simple_value_handles_rollover_year():
+    query_str = 'date 2017-12'
+    expected_es_query = \
+        {
+            "bool": {
+                "should": [
+                    {"range": {"earliest_date": {"gte": "2017-12||/M", "lt": "2018-01||/M"}}},
+                    {"range": {"imprints.date": {"gte": "2017-12||/M", "lt": "2018-01||/M"}}},
+                    {"range": {"preprint_date": {"gte": "2017-12||/M", "lt": "2018-01||/M"}}},
+                    {"range": {"publication_info.year": {"gte": "2017||/y", "lt": "2018||/y"}}},
+                    {"range": {"thesis_info.date": {"gte": "2017-12||/M", "lt": "2018-01||/M"}}},
+                ]
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_with_date_multi_field_and_simple_value_handles_rollover_month():
+    query_str = 'date 2017-10-31'
+    expected_es_query = \
+        {
+            "bool": {
+                "should": [
+                    {"range": {"earliest_date": {"gte": "2017-10-31||/d", "lt": "2017-11-01||/d"}}},
+                    {"range": {"imprints.date": {"gte": "2017-10-31||/d", "lt": "2017-11-01||/d"}}},
+                    {"range": {"preprint_date": {"gte": "2017-10-31||/d", "lt": "2017-11-01||/d"}}},
+                    {"range": {"publication_info.year": {"gte": "2017||/y", "lt": "2018||/y"}}},
+                    {"range": {"thesis_info.date": {"gte": "2017-10-31||/d", "lt": "2017-11-01||/d"}}},
+                ]
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_with_date_multi_field_and_wildcard_value_suffix_in_day():
     query_str = 'date 2000-10-*'
     expected_es_query = \
         {
-            "query_string": {
-                "analyze_wildcard": True,
-                "fields": [
-                    "earliest_date",
-                    "imprints.date",
-                    "preprint_date",
-                    "publication_info.year",
-                    "thesis_info.date",
-                ],
-                "query": "2000-10-*",
+            "bool": {
+                "should": [
+                    {"range": {"earliest_date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
+                    {"range": {"imprints.date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
+                    {"range": {"preprint_date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
+                    {"range": {"publication_info.year": {"gte": "2000||/y", "lt": "2001||/y"}}},
+                    {"range": {"thesis_info.date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
+                ]
             }
         }
 
@@ -714,7 +751,126 @@ def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_val
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_exact_match_value():
+def test_elastic_search_visitor_with_date_multi_field_and_wildcard_value_suffix_in_month():
+    query_str = 'date 2015-*'
+    expected_es_query = \
+        {
+            "bool": {
+                "should": [
+                    {"range": {"earliest_date": {"gte": "2015||/y", "lt": "2016||/y"}}},
+                    {"range": {"imprints.date": {"gte": "2015||/y", "lt": "2016||/y"}}},
+                    {"range": {"preprint_date": {"gte": "2015||/y", "lt": "2016||/y"}}},
+                    {"range": {"publication_info.year": {"gte": "2015||/y", "lt": "2016||/y"}}},
+                    {"range": {"thesis_info.date": {"gte": "2015||/y", "lt": "2016||/y"}}},
+                ]
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_with_date_multi_field_and_wildcard_value_suffix_as_month_part():
+    query_str = 'date 2015-1*'
+    expected_es_query = \
+        {
+            "bool": {
+                "should": [
+                    {"range": {"earliest_date": {"gte": "2015||/y", "lt": "2016||/y"}}},
+                    {"range": {"imprints.date": {"gte": "2015||/y", "lt": "2016||/y"}}},
+                    {"range": {"preprint_date": {"gte": "2015||/y", "lt": "2016||/y"}}},
+                    {"range": {"publication_info.year": {"gte": "2015||/y", "lt": "2016||/y"}}},
+                    {"range": {"thesis_info.date": {"gte": "2015||/y", "lt": "2016||/y"}}},
+                ]
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_with_one_query_date_multi_field_and_wildcard_infix_generates_to_all_field():
+    query_str = 'date: 2017-*-12'
+    expected_es_query = \
+        {
+            "multi_match": {
+                "fields": ["_all"],
+                "query": "date 2017-*-12",
+                "zero_terms_query": "all",
+            }
+        }
+
+    generated_es_query = parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_with_two_queries_date_multi_field_and_wildcard_infix_drops_date():
+    query_str = 'date: 2017-*-12 and title collider'
+    expected_es_query = \
+        {
+            "bool": {
+                "must": [
+                    {
+                        "match": {
+                            "titles.full_title": {
+                                "query": "collider",
+                                "operator": "and",
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+
+    generated_es_query = parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_with_date_multi_field_and_wildcard_value_suffix_in_year_drops_date_query():
+    query_str = 'date 201* and title collider'
+    expected_es_query = \
+        {
+            "bool": {
+                "must": [
+                    {
+                        "match": {
+                            "titles.full_title": {
+                                "query": "collider",
+                                "operator": "and",
+                            }
+                        }
+                    },
+                ]
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_with_date_multi_field_and_wildcard_value_suffix_in_month_drops_date_query():
+    query_str = 'date 2000-*-01 and title collider'
+    expected_es_query = \
+        {
+            "bool": {
+                "must": [
+                    {
+                        "match": {
+                            "titles.full_title": {
+                                "query": "collider",
+                                "operator": "and",
+                            }
+                        }
+                    },
+                ]
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_with_date_multi_field_and_exact_match_value():
     query_str = 'date "2000-10"'
     expected_es_query = \
         {
@@ -737,7 +893,7 @@ def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_exa
                     },
                     {
                         "term": {
-                            "publication_info.year": "2000-10"
+                            "publication_info.year": "2000"
                         }
                     },
                     {
@@ -753,20 +909,18 @@ def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_exa
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_partial_match_value():
-    query_str = 'date \'2000-10\''
+def test_elastic_search_visitor_with_date_multi_field_and_partial_value():
+    query_str = "date '2000-10'"
     expected_es_query = \
         {
-            "query_string": {
-                "analyze_wildcard": True,
-                "fields": [
-                    "earliest_date",
-                    "imprints.date",
-                    "preprint_date",
-                    "publication_info.year",
-                    "thesis_info.date",
-                ],
-                "query": "*2000-10*",
+            "bool": {
+                "should": [
+                    {"range": {"earliest_date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
+                    {"range": {"imprints.date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
+                    {"range": {"preprint_date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
+                    {"range": {"publication_info.year": {"gte": "2000||/y", "lt": "2001||/y"}}},
+                    {"range": {"thesis_info.date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
+                ]
             }
         }
 
@@ -774,20 +928,18 @@ def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_par
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_partial_match_value_with_wildcard():
+def test_elastic_search_visitor_with_date_multi_field_and_partial_value_with_wildcard():
     query_str = 'date \'2000-10-*\''
     expected_es_query = \
         {
-            "query_string": {
-                "analyze_wildcard": True,
-                "fields": [
-                    "earliest_date",
-                    "imprints.date",
-                    "preprint_date",
-                    "publication_info.year",
-                    "thesis_info.date",
-                ],
-                "query": "*2000-10-*",
+            "bool": {
+                "should": [
+                    {"range": {"earliest_date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
+                    {"range": {"imprints.date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
+                    {"range": {"preprint_date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
+                    {"range": {"publication_info.year": {"gte": "2000||/y", "lt": "2001||/y"}}},
+                    {"range": {"thesis_info.date": {"gte": "2000-10||/M", "lt": "2000-11||/M"}}},
+                ]
             }
         }
 
@@ -795,24 +947,45 @@ def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_par
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_range_value():
-    query_str = 'date 2000->2005'
-    expected_es_query = \
-        {
-            "range": {
-                "earliest_date": {"gte": "2000", "lte": "2005"},
-                "imprints.date": {"gte": "2000", "lte": "2005"},
-                "preprint_date": {"gte": "2000", "lte": "2005"},
-                "publication_info.year": {"gte": "2000", "lte": "2005"},
-                "thesis_info.date": {"gte": "2000", "lte": "2005"},
-            }
+def test_elastic_search_visitor_with_date_multi_field_and_range_op():
+    query_str = 'date 2000-01->2001-01'
+    expected_es_query = {
+        "bool": {
+            "should": [
+                {"range": {"earliest_date": {"gte": "2000-01||/M", "lte": "2001-01||/M"}}},
+                {"range": {"imprints.date": {"gte": "2000-01||/M", "lte": "2001-01||/M"}}},
+                {"range": {"preprint_date": {"gte": "2000-01||/M", "lte": "2001-01||/M"}}},
+                {"range": {"publication_info.year": {"gte": "2000||/y", "lte": "2001||/y"}}},
+                {"range": {"thesis_info.date": {"gte": "2000-01||/M", "lte": "2001-01||/M"}}},
+            ]
         }
+    }
 
     generated_es_query = _parse_query(query_str)
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_gt_op():
+def test_elastic_search_visitor_with_date_multi_field_range_within_same_year():
+    # This kind of query works fine (regarding the ``publication_info.year``), since the range operator is including
+    # its bounds, otherwise we would get no records.
+    query_str = 'date 2000-01->2000-04'
+    expected_es_query = {
+        "bool": {
+            "should": [
+                {"range": {"earliest_date": {"gte": "2000-01||/M", "lte": "2000-04||/M"}}},
+                {"range": {"imprints.date": {"gte": "2000-01||/M", "lte": "2000-04||/M"}}},
+                {"range": {"preprint_date": {"gte": "2000-01||/M", "lte": "2000-04||/M"}}},
+                {"range": {"publication_info.year": {"gte": "2000||/y", "lte": "2000||/y"}}},
+                {"range": {"thesis_info.date": {"gte": "2000-01||/M", "lte": "2000-04||/M"}}},
+            ]
+        }
+    }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_with_date_multi_field_and_gt_op():
     query_str = 'title γ-radiation and date > 2015'
     expected_es_query = \
         {
@@ -827,12 +1000,14 @@ def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_gt_
                         }
                     },
                     {
-                        "range": {
-                            "earliest_date": {"gt": "2015"},
-                            "imprints.date": {"gt": "2015"},
-                            "preprint_date": {"gt": "2015"},
-                            "publication_info.year": {"gt": "2015"},
-                            "thesis_info.date": {"gt": "2015"},
+                        "bool": {
+                            "should": [
+                                {"range": {"earliest_date": {"gt": "2015||/y"}}},
+                                {"range": {"imprints.date": {"gt": "2015||/y"}}},
+                                {"range": {"preprint_date": {"gt": "2015||/y"}}},
+                                {"range": {"publication_info.year": {"gt": "2015||/y"}}},
+                                {"range": {"thesis_info.date": {"gt": "2015||/y"}}},
+                            ]
                         }
                     }
                 ]
@@ -843,7 +1018,7 @@ def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_gt_
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_gte_op():
+def test_elastic_search_visitor_with_date_multi_field_and_gte_op():
     query_str = 'title γ-radiation and date 2015+'
     expected_es_query = \
         {
@@ -858,12 +1033,14 @@ def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_gte
                         }
                     },
                     {
-                        "range": {
-                            "earliest_date": {"gte": "2015"},
-                            "imprints.date": {"gte": "2015"},
-                            "preprint_date": {"gte": "2015"},
-                            "publication_info.year": {"gte": "2015"},
-                            "thesis_info.date": {"gte": "2015"},
+                        "bool": {
+                            "should": [
+                                {"range": {"earliest_date": {"gte": "2015||/y"}}},
+                                {"range": {"imprints.date": {"gte": "2015||/y"}}},
+                                {"range": {"preprint_date": {"gte": "2015||/y"}}},
+                                {"range": {"publication_info.year": {"gte": "2015||/y"}}},
+                                {"range": {"thesis_info.date": {"gte": "2015||/y"}}},
+                            ]
                         }
                     }
                 ]
@@ -874,8 +1051,8 @@ def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_gte
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_lt_op():
-    query_str = 'title γ-radiation and date < 2015'
+def test_elastic_search_visitor_with_date_multi_field_and_lt_op():
+    query_str = 'title γ-radiation and date < 2015-08'
     expected_es_query = \
         {
             "bool": {
@@ -889,12 +1066,14 @@ def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_lt_
                         }
                     },
                     {
-                        "range": {
-                            "earliest_date": {"lt": "2015"},
-                            "imprints.date": {"lt": "2015"},
-                            "preprint_date": {"lt": "2015"},
-                            "publication_info.year": {"lt": "2015"},
-                            "thesis_info.date": {"lt": "2015"},
+                        "bool": {
+                            "should": [
+                                {"range": {"earliest_date": {"lt": "2015-08||/M"}}},
+                                {"range": {"imprints.date": {"lt": "2015-08||/M"}}},
+                                {"range": {"preprint_date": {"lt": "2015-08||/M"}}},
+                                {"range": {"publication_info.year": {"lt": "2015||/y"}}},
+                                {"range": {"thesis_info.date": {"lt": "2015-08||/M"}}},
+                            ]
                         }
                     }
                 ]
@@ -905,8 +1084,8 @@ def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_lt_
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_lte_op():
-    query_str = 'title γ-radiation and date 2015-'
+def test_elastic_search_visitor_with_date_multi_field_and_lte_op():
+    query_str = 'title γ-radiation and date 2015-08-30-'
     expected_es_query = \
         {
             "bool": {
@@ -920,12 +1099,72 @@ def test_elastic_search_visitor_with_multi_match_when_es_field_is_a_list_and_lte
                         }
                     },
                     {
-                        "range": {
-                            "earliest_date": {"lte": "2015"},
-                            "imprints.date": {"lte": "2015"},
-                            "preprint_date": {"lte": "2015"},
-                            "publication_info.year": {"lte": "2015"},
-                            "thesis_info.date": {"lte": "2015"},
+                        "bool": {
+                            "should": [
+                                {"range": {"earliest_date": {"lte": "2015-08-30||/d"}}},
+                                {"range": {"imprints.date": {"lte": "2015-08-30||/d"}}},
+                                {"range": {"preprint_date": {"lte": "2015-08-30||/d"}}},
+                                {"range": {"publication_info.year": {"lte": "2015||/y"}}},
+                                {"range": {"thesis_info.date": {"lte": "2015-08-30||/d"}}},
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_with_date_malformed_drops_boolean_query_2nd_part():
+    query_str = 'title γ-radiation and date > 2015_08'
+    expected_es_query = \
+        {
+            "bool": {
+                "must": [
+                    {
+                        "match": {
+                            "titles.full_title": {
+                                "query": "γ-radiation",
+                                "operator": "and",
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_with_date_malformed_drops_boolean_query_both_parts():
+    query_str = 'date > 2015_08 and date < 2016_10'
+    expected_es_query = {}  # Equivalent to match_all query.
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_drops_empty_body_boolean_queries():
+    query_str = 'date > 2015_08 and date < 2016_10 and title γ-radiation'
+    expected_es_query = \
+        {
+            "bool": {
+                "must": [
+                    {
+                        "bool": {
+                            "must": [
+                                {
+                                    "match": {
+                                        "titles.full_title": {
+                                            "query": "γ-radiation",
+                                            "operator": "and",
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     }
                 ]

--- a/tests/test_parsing_driver.py
+++ b/tests/test_parsing_driver.py
@@ -126,3 +126,18 @@ def test_driver_with_es_visitor_error(mocked_es_visitor):
     es_query = parse_query(query_str)
 
     assert es_query == expected_es_query
+
+
+def test_driver_with_es_visitor_empty_query_generates_a_query_against_all():
+    query_str = 'd < 200'
+    expected_es_query = {
+        'multi_match': {
+            'query': 'd < 200',
+            'fields': ['_all'],
+            'zero_terms_query': 'all'
+        }
+    }
+
+    es_query = parse_query(query_str)
+
+    assert es_query == expected_es_query

--- a/tests/test_visitor_utils.py
+++ b/tests/test_visitor_utils.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, unicode_literals
+
+from pytest import raises
+
+from inspire_query_parser.utils.visitor_utils import _truncate_wildcard_from_date
+
+from test_utils import parametrize
+
+
+@parametrize({
+    'Wildcard as whole day': {
+        'date': '2018-01-*', 'expected_date': '2018-01'
+    },
+    'Wildcard as part of the day': {
+        'date': '2018-01-1*', 'expected_date': '2018-01'
+    },
+    'Wildcard as whole day (space separated)': {
+        'date': '2018 01 *', 'expected_date': '2018-01'
+    },
+    'Wildcard as part of the day (space separated)': {
+        'date': '2018 01 1*', 'expected_date': '2018-01'
+    },
+
+    'Wildcard as whole month': {
+        'date': '2018-*', 'expected_date': '2018'
+    },
+    'Wildcard as part of the month': {
+        'date': '2018-*', 'expected_date': '2018'
+    },
+    'Wildcard as whole month (space separated)': {
+        'date': '2018 *', 'expected_date': '2018'
+    },
+    'Wildcard as part of the month (space separated)': {
+        'date': '2018 1*', 'expected_date': '2018'
+    },
+})
+def test_truncate_wildcard_from_date_with_wildcard(date, expected_date):
+    assert _truncate_wildcard_from_date(date) == expected_date
+
+
+def test_truncate_wildcard_from_date_throws_on_wildcard_in_year():
+    date = '201*'
+    with raises(ValueError):
+        _truncate_wildcard_from_date(date)
+
+
+def test_truncate_wildcard_from_date_throws_with_unsupported_separator():
+    date = '2018_1*'
+    with raises(ValueError):
+        _truncate_wildcard_from_date(date)


### PR DESCRIPTION
Rewrite of date queries (closes #73):
* Converts mutli-field range queries to a chain of bool.should clauses
  so that if a field doesn't exist in a record, the query will still
  produce results. Same processing happens for date range queries.

* Date queries with equality and Value or Partial value are transformed
  into range queries, starting from the given date and up to the next
  date (according to the granularity of the date typed by the user).

* Uses PartialDate from inspire-utils, so that it drops all given date
  parts except for the year, for fields that only contain a year
  (otherwise the query in ES errors out).

* Add simple support for wildcard operator in simple and partial match
  value date queries. The policy followed is:
  * if the whole date part is a wildcard, then we ignore it and do a
    range query on the remaining parts (e.g. '2018-*' -> '2018')
  * Some number is wildcard, where again, we ignore this part. If all
    parts are ignored then we drop the date query.
  * For queries where the wildcard operator is not as a suffix (e.g.
    '2017-1*-01'), we drop the date query.

* es-visitor: date queries use ES date rounding
  This feature is used in all cases, i.e. range and equality queries.
  This is needed for supporting range queries on dates, i.e. rounding
  them up or down according to the ES range operator.

  For example, without this, a query like 'date > 2010-11', would return
  documents with date '2010-11-15', due to the date value of the query
  being interpreted by ES as '2010-11-01 01:00:00'.

  By using the suffixes for rounding up or down, the date value of the
  query is interpreted as '2010-11-30T23:59:59.999', thus not returning
  the document with date '2010-11-15', as the user would expect. See:
  https://www.elastic.co/guide/en/elasticsearch/reference/6.1/query-dsl-range-query.html#_date_math_and_rounding

* In case of malformed date the related range query is dropped.
  Consequently, ``visit_boolean_rule`` in case of both conditions being
  empty, generates an empty query (equivalent to match_all).

* parsing_driver: generate query on empty query from ES visitor
  Ensure that a query is generated at all times, if an empty query "{}"
  is returned from ES visitor, otherwise ElasticSearch DSL breaks when
  trying to wrap parser's return value in a Q object.

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>