### PR TITLE
rst-visitor: {last, this} month respect current day

### DIFF
--- a/inspire_query_parser/utils/visitor_utils.py
+++ b/inspire_query_parser/utils/visitor_utils.py
@@ -192,7 +192,7 @@ def convert_yesterday_date_specifier(relative_date_specifier_suffix):
 
 @register_date_conversion_handler(DATE_THIS_MONTH_REGEX_PATTERN)
 def convert_this_month_date(relative_date_specifier_suffix):
-    start_date = date.today().replace(day=1)
+    start_date = date.today()
     relative_delta = (
         relativedelta(months=_extract_number_from_text(relative_date_specifier_suffix))
         if relative_date_specifier_suffix else None
@@ -203,7 +203,7 @@ def convert_this_month_date(relative_date_specifier_suffix):
 
 @register_date_conversion_handler(DATE_LAST_MONTH_REGEX_PATTERN)
 def convert_last_month_date(relative_date_specifier_suffix):
-    start_date = date.today().replace(day=1) - relativedelta(months=1)
+    start_date = date.today() - relativedelta(months=1)
     relative_delta = (
         relativedelta(months=_extract_number_from_text(relative_date_specifier_suffix))
         if relative_date_specifier_suffix else None

--- a/tests/test_restructuring_visitor.py
+++ b/tests/test_restructuring_visitor.py
@@ -415,14 +415,14 @@ from inspire_query_parser.visitors.restructuring_visitor import \
         (
             'date this month author ellis',
             AndOp(
-                KeywordOp(Keyword('date'), Value(str(date.today().replace(day=1)))),
+                KeywordOp(Keyword('date'), Value(str(date.today()))),
                 KeywordOp(Keyword('author'), Value('ellis'))
             )
          ),
         (
             'date this month - 3 author ellis',
             AndOp(
-                KeywordOp(Keyword('date'), Value(str(date.today().replace(day=1) - relativedelta(months=3)))),
+                KeywordOp(Keyword('date'), Value(str(date.today() - relativedelta(months=3)))),
                 KeywordOp(Keyword('author'), Value('ellis'))
             )
          ),
@@ -437,7 +437,7 @@ from inspire_query_parser.visitors.restructuring_visitor import \
         (
             'date last month - 2 + ac < 50',
             AndOp(
-                KeywordOp(Keyword('date'), Value(str((date.today().replace(day=1) - relativedelta(months=3))))),
+                KeywordOp(Keyword('date'), Value(str((date.today() - relativedelta(months=3))))),
                 KeywordOp(Keyword('author-count'), LessThanOp(Value('50')))
             )
          ),


### PR DESCRIPTION
{Last, this} month date specifiers now respect the current day while
doing the other transformations as usual. E.g. last month - 2, if done
on the date of this commit, will be transformed to a date query with
value 2017-12-24 (closes #85).

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>