### PR TITLE
Add journal nested queries support

### DIFF
--- a/inspire_query_parser/utils/visitor_utils.py
+++ b/inspire_query_parser/utils/visitor_utils.py
@@ -359,3 +359,78 @@ def update_date_value_in_operator_value_pairs_for_fieldname(field, operator_valu
                 modified_date.dumps() + _get_proper_elastic_search_date_rounding_format(modified_date)
 
     return updated_operator_value_pairs
+
+
+# #### Generic ElasticSearch DSL generation helpers ####
+def generate_match_query(field, value, with_operator_and):
+    """Helper for generating a match query.
+
+    Args:
+        field (six.text_type): The ES field to be queried.
+        value (six.text_type/bool): The value of the query (bool for the case of type-code query ["core: true"]).
+        with_operator_and (bool): Flag that signifies whether to generate the explicit notation of the query, along
+            with '"operator": "and"', so that all tokens of the query value are required to match.
+
+    Notes:
+        If value is of instance bool, then the shortened version of the match query is generated, at all times.
+    """
+    if isinstance(value, bool):
+        return {'match': {field: value}}
+
+    if with_operator_and:
+        return {
+            'match': {
+                field: {
+                    'query': value,
+                    'operator': 'and'
+                }
+            }
+        }
+
+    return {'match': {field: value}}
+
+
+def generate_nested_query(path, queries):
+    """Generates nested query.
+
+    Returns:
+        (dict): The nested query if queries is not falsy, otherwise an empty dict.
+    """
+    if not queries:
+        return {}
+
+    return {
+        'nested': {
+            'path': path,
+            'query': queries
+        }
+    }
+
+
+def wrap_queries_in_bool_clauses_if_more_than_one(queries,
+                                                  use_must_clause,
+                                                  preserve_bool_semantics_if_one_clause=False):
+    """Helper for wrapping a list of queries into a bool.{must, should} clause.
+
+    Args:
+        queries (list): List of queries to be wrapped in a bool.{must, should} clause.
+        use_must_clause (bool): Flag that signifies whether to use 'must' or 'should' clause.
+        preserve_bool_semantics_if_one_clause (bool): Flag that signifies whether to generate a bool query even if
+            there's only one clause. This happens to generate boolean query semantics. Usually not the case, but
+            useful for boolean queries support.
+
+    Returns:
+        (dict): If len(queries) > 1, the bool clause, otherwise if len(queries) == 1, will return the query itself,
+                while finally, if len(queries) == 0, then an empty dictionary is returned.
+    """
+    if not queries:
+        return {}
+
+    if len(queries) == 1 and not preserve_bool_semantics_if_one_clause:
+        return queries[0]
+
+    return {
+        'bool': {
+            ('must' if use_must_clause else 'should'): queries
+        }
+    }

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup_requires = [
 ]
 
 install_requires=[
-    'inspire-utils~=2.0,>=2.0.0',
+    'inspire-schemas~=57.0,>=57.0.4',
     'pypeg2~=2.0,>=2.15.2',
     'python-dateutil~=2.0,>=2.6.1',
     'six~=1.0,>=1.11.0',

--- a/tests/test_restructuring_visitor.py
+++ b/tests/test_restructuring_visitor.py
@@ -260,10 +260,7 @@ from inspire_query_parser.visitors.restructuring_visitor import \
         (
             'find (j phys.rev. and vol d85) or (j phys.rev.lett.,62,1825)',
             OrOp(
-                AndOp(
-                    KeywordOp(Keyword('journal'), Value('phys.rev.')),
-                    KeywordOp(Keyword('volume'), Value('d85'))
-                ),
+                KeywordOp(Keyword('journal'), Value('phys.rev.,d85')),
                 KeywordOp(Keyword('journal'), Value('phys.rev.lett.,62,1825'))
             )
          ),
@@ -485,7 +482,74 @@ from inspire_query_parser.visitors.restructuring_visitor import \
                 KeywordOp(Keyword('title'), Value('γ-radiation')),
                 MalformedQuery(['and', 'and'])
             )
-         )
+         ),
+        ('find j Nucl.Phys.,A531,11', KeywordOp(Keyword('journal'), Value('Nucl.Phys.,A531,11'))),
+        (
+            'find j Nucl.Phys. and j Nucl.Phys.',
+            AndOp(
+                KeywordOp(Keyword('journal'), Value('Nucl.Phys.')),
+                KeywordOp(Keyword('journal'), Value('Nucl.Phys.'))
+            )
+        ),
+        (
+            'find j Nucl.Phys. and vol A351 and author ellis',
+            AndOp(
+                KeywordOp(Keyword('journal'), Value('Nucl.Phys.,A351')),
+                KeywordOp(Keyword('author'), Value('ellis'))
+            )
+        ),
+        (
+            'find j Nucl.Phys. and vol A351 and author ellis and author smith and ea john',
+            AndOp(
+                KeywordOp(Keyword('journal'), Value('Nucl.Phys.,A351')),
+                AndOp(
+                    KeywordOp(Keyword('author'), Value('ellis')),
+                    AndOp(
+                        KeywordOp(Keyword('author'), Value('smith')),
+                        KeywordOp(Keyword('exact-author'), Value('john'))
+                    )
+                )
+            )
+        ),
+        ('find j Nucl.Phys. and vol A531', KeywordOp(Keyword('journal'), Value('Nucl.Phys.,A531'))),
+        (
+            'find j Nucl.Phys. and author ellis',
+            AndOp(
+                KeywordOp(Keyword('journal'), Value('Nucl.Phys.')),
+                KeywordOp(Keyword('author'), Value('ellis'))
+            )
+        ),
+        (
+            'find author ellis and j Nucl.Phys. and vol B351 and title Collider',
+            AndOp(
+                KeywordOp(Keyword('author'), Value('ellis')),
+                AndOp(
+                    KeywordOp(Keyword('journal'), Value('Nucl.Phys.,B351')),
+                    KeywordOp(Keyword('title'), Value('Collider'))
+                )
+            )
+        ),
+        (
+            'find author ellis and j Nucl.Phys. and vol B351 and title Collider',
+            AndOp(
+                KeywordOp(Keyword('author'), Value('ellis')),
+                AndOp(
+                    KeywordOp(Keyword('journal'), Value('Nucl.Phys.,B351')),
+                    KeywordOp(Keyword('title'), Value('Collider'))
+                )
+            )
+        ),
+        ('find j Nucl.Phys. and not vol A531', KeywordOp(Keyword('journal'), Value('Nucl.Phys.'))),
+        (
+            'find j Nucl.Phys. and not vol A531 and a ellis and a john',
+            AndOp(
+                KeywordOp(Keyword('journal'), Value('Nucl.Phys.')),
+                AndOp(
+                    KeywordOp(Keyword('author'), Value('ellis')),
+                    KeywordOp(Keyword('author'), Value('john'))
+                )
+            )
+        )
     ]
 )
 def test_restructuring_visitor_functionality(query_str, expected_parse_tree):
@@ -494,6 +558,19 @@ def test_restructuring_visitor_functionality(query_str, expected_parse_tree):
     restructuring_visitor = RestructuringVisitor()
     _, parse_tree = stateful_parser.parse(query_str, parser.Query)
     parse_tree = parse_tree.accept(restructuring_visitor)
+
+    assert parse_tree == expected_parse_tree
+
+
+def test_foo_bar():
+    query_str = 'find j Nucl.Phys. and not vol A531 and a ellis'
+    print("Parsing: " + query_str)
+    stateful_parser = StatefulParser()
+    restructuring_visitor = RestructuringVisitor()
+    _, parse_tree = stateful_parser.parse(query_str, parser.Query)
+    parse_tree = parse_tree.accept(restructuring_visitor)
+    expected_parse_tree = AndOp(KeywordOp(Keyword('journal'), Value('Nucl.Phys.')),
+                                KeywordOp(Keyword('author'), Value('ellis')))
 
     assert parse_tree == expected_parse_tree
 


### PR DESCRIPTION
* es-visitor: add support for journal queries on journal title, journal
volume and artid/page start.

* restructuring-visitor: implement `journal and vol` query support and
drop the `vol` part of `journal and not vol` queries.

* setup: depend on `inspire-schemas`, since we require `convert_old_publication_info_to_new`.
For that reason, `inspire-utils` is dropped as a dependency, in place of `inspire-schemas`.

* `convert_old_publication_info_to_new` of `inspire-schemas` is used
for supporting journal keyword queries.

* Use `convert_old_publication_info_to_new` of `inspire-schemas` to
preprocess and validate the searched values, i.e. the journal_title,
journal_volume and artid/page_start.

* utils: add generic functions for generating nested, match
and bool queries.

* Ensure journal queries are the same for either Value, ExactValue and
PartialValue.

Signed-off-by: Iuliana Voinea <iuliana.voinea@student.manchester.ac.uk>
Co-authored-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>