### PR TITLE
elastic_search_visitor: nested exact author queries

### DIFF
--- a/inspire_query_parser/visitors/elastic_search_visitor.py
+++ b/inspire_query_parser/visitors/elastic_search_visitor.py
@@ -140,6 +140,7 @@ class ElasticSearchVisitor(Visitor):
     AUTHORS_BAI_FIELD = 'authors.ids.value'
     BAI_REGEX = re.compile(r'^((\w|-|\')+\.)+\d+$', re.UNICODE | re.IGNORECASE)
     JOURNAL_NESTED_QUERY_PATH = 'publication_info'
+    AUTHORS_NESTED_QUERY_PATH = 'authors'
     TITLE_SYMBOL_INDICATING_CHARACTER = ['-', '(', ')']
     # ################
 
@@ -250,16 +251,18 @@ class ElasticSearchVisitor(Visitor):
             'j. smith', 'J Smith', 'J. Smith'.
         """
         if ElasticSearchVisitor.BAI_REGEX.match(author_name_or_bai):
-            return self._generate_term_query(
+            query = self._generate_term_query(
                 '.'.join((ElasticSearchVisitor.AUTHORS_BAI_FIELD, FieldVariations.raw)),
                 author_name_or_bai
             )
         else:
             author_name = normalize('NFKC', normalize_name(author_name_or_bai)).lower()
-            return self._generate_term_query(
+            query = self._generate_term_query(
                 ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['exact-author'],
                 author_name
             )
+
+        return generate_nested_query(ElasticSearchVisitor.AUTHORS_NESTED_QUERY_PATH, query)
 
     def _generate_date_with_wildcard_query(self, date_value):
         """Helper for generating a date keyword query containing a wildcard.

--- a/tests/test_elastic_search_visitor.py
+++ b/tests/test_elastic_search_visitor.py
@@ -96,8 +96,13 @@ def test_elastic_search_visitor_find_exact_author_simple_value():
     query_str = 'ea Vures, John I.'
     expected_es_query = \
         {
-            "term": {
-                "authors.full_name_unicode_normalized": "vures, john i."
+            "nested": {
+                "path": "authors",
+                "query": {
+                    "term": {
+                        "authors.full_name_unicode_normalized": "vures, john i."
+                    }
+                }
             }
         }
 
@@ -109,8 +114,13 @@ def test_elastic_search_visitor_find_exact_author_simple_value_diacritics():
     query_str = 'ea Vurës, John I'
     expected_es_query = \
         {
-            "term": {
-                "authors.full_name_unicode_normalized": "vur\xebs, john i."
+            "nested": {
+                "path": "authors",
+                "query": {
+                    "term": {
+                        "authors.full_name_unicode_normalized": "vur\xebs, john i."
+                    }
+                }
             }
         }
 
@@ -122,8 +132,13 @@ def test_elastic_search_visitor_find_exact_author_partial_value():
     query_str = "ea 'Vures, John I.'"
     expected_es_query = \
         {
-            "term": {
-                "authors.full_name_unicode_normalized": "vures, john i."
+            "nested": {
+                "path": "authors",
+                "query": {
+                    "term": {
+                        "authors.full_name_unicode_normalized": "vures, john i."
+                    }
+                }
             }
         }
 
@@ -135,8 +150,13 @@ def test_elastic_search_visitor_find_exact_author_partial_value_diacritics():
     query_str = "ea 'Vurës, John I'"
     expected_es_query = \
         {
-            "term": {
-                "authors.full_name_unicode_normalized": "vur\xebs, john i."
+            "nested": {
+                "path": "authors",
+                "query": {
+                    "term": {
+                        "authors.full_name_unicode_normalized": "vur\xebs, john i."
+                    }
+                }
             }
         }
 
@@ -148,8 +168,13 @@ def test_elastic_search_visitor_find_exact_author_exact_value():
     query_str = 'ea "Vures, John I."'
     expected_es_query = \
         {
-            "term": {
-                "authors.full_name_unicode_normalized": "vures, john i."
+            "nested": {
+                "path": "authors",
+                "query": {
+                    "term": {
+                        "authors.full_name_unicode_normalized": "vures, john i."
+                    }
+                }
             }
         }
 
@@ -161,8 +186,13 @@ def test_elastic_search_visitor_find_exact_author_exact_value_diacritics():
     query_str = 'ea "Vurës, John I"'
     expected_es_query = \
         {
-            "term": {
-                "authors.full_name_unicode_normalized": "vur\xebs, john i."
+            "nested": {
+                "path": "authors",
+                "query": {
+                    "term": {
+                        "authors.full_name_unicode_normalized": "vur\xebs, john i."
+                    }
+                }
             }
         }
 
@@ -174,8 +204,13 @@ def test_elastic_search_visitor_find_exact_author_with_bai_simple_value_ellis():
     query_str = 'ea J.Ellis.4'
     expected_es_query = \
         {
-            "term": {
-                "authors.ids.value.raw": "J.Ellis.4"
+            "nested": {
+                "path": "authors",
+                "query": {
+                    "term": {
+                        "authors.ids.value.raw": "J.Ellis.4"
+                    }
+                }
             }
         }
 
@@ -187,8 +222,13 @@ def test_elastic_search_visitor_find_exact_author_with_bai_exact_value_ellis():
     query_str = 'ea "J.Ellis.4"'
     expected_es_query = \
         {
-            "term": {
-                "authors.ids.value.raw": "J.Ellis.4"
+            "nested": {
+                "path": "authors",
+                "query": {
+                    "term": {
+                        "authors.ids.value.raw": "J.Ellis.4"
+                    }
+                }
             }
         }
 
@@ -200,8 +240,13 @@ def test_elastic_search_visitor_find_exact_author_with_bai_partial_value_ellis()
     query_str = "ea 'J.Ellis.4'"
     expected_es_query = \
         {
-            "term": {
-                "authors.ids.value.raw": "J.Ellis.4"
+            "nested": {
+                "path": "authors",
+                "query": {
+                    "term": {
+                        "authors.ids.value.raw": "J.Ellis.4"
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Make exact author queries nested in order to be compatible with the 'author' field which has been changed to nested.

Signed-off-by: Iuliana Voinea <iulianavoinea96@gmail.com>