### PR TITLE
elastic_search_visitor: handle unknown fieldnames

### DIFF
--- a/inspire_query_parser/utils/visitor_utils.py
+++ b/inspire_query_parser/utils/visitor_utils.py
@@ -434,3 +434,26 @@ def wrap_queries_in_bool_clauses_if_more_than_one(queries,
             ('must' if use_must_clause else 'should'): queries
         }
     }
+
+
+def wrap_queries_in_dis_max_clause_if_more_than_one(queries):
+    """Helper for wrapping a list of queries into a dis_max clause.
+
+    Args:
+        queries (list): List of queries to be wrapped in a dis_max clause.
+
+    Returns:
+        (dict): If len(queries) > 1, the dis_max clause, otherwise if len(queries) == 1, will return the query itself,
+                while finally, if len(queries) == 0, then an empty dictionary is returned.
+    """
+    if not queries:
+        return {}
+
+    if len(queries) == 1:
+        return queries[0]
+
+    return {
+        'dis_max': {
+            'queries': queries,
+        }
+    }

--- a/tests/test_elastic_search_visitor.py
+++ b/tests/test_elastic_search_visitor.py
@@ -467,11 +467,25 @@ def test_elastic_search_visitor_or_op_query():
 def test_elastic_search_visitor_unknown_keyword_simple_value():
     query_str = 'unknown_keyword:bar'
     expected_es_query = {
-        "match": {
-            "unknown_keyword": {
-                "query": "bar",
-                "operator": "and",
-            }
+        "dis_max": {
+            "queries": [
+                {
+                    "match": {
+                        "unknown_keyword": {
+                            "query": "bar",
+                            "operator": "and",
+                        }
+                    }
+                },
+                {
+                    "match": {
+                        "_all": {
+                            "query": "unknown_keyword:bar",
+                            "operator": "and",
+                        }
+                    }
+                }
+            ]
         }
     }
 
@@ -482,11 +496,25 @@ def test_elastic_search_visitor_unknown_keyword_simple_value():
 def test_elastic_search_visitor_dotted_keyword_simple_value():
     query_str = 'dotted.keyword:bar'
     expected_es_query = {
-        "match": {
-            "dotted.keyword": {
-                "query": "bar",
-                "operator": "and",
-            }
+        "dis_max": {
+            "queries": [
+                {
+                    "match": {
+                        "dotted.keyword": {
+                            "query": "bar",
+                            "operator": "and",
+                        }
+                    }
+                },
+                {
+                    "match": {
+                        "_all": {
+                            "query": "dotted.keyword:bar",
+                            "operator": "and",
+                        }
+                    }
+                }
+            ]
         }
     }
 

--- a/tests/test_visitor_utils.py
+++ b/tests/test_visitor_utils.py
@@ -31,6 +31,7 @@ from inspire_query_parser.utils.visitor_utils import (
     generate_minimal_name_variations,
     generate_nested_query,
     wrap_queries_in_bool_clauses_if_more_than_one,
+    wrap_queries_in_dis_max_clause_if_more_than_one,
 )
 
 from test_utils import parametrize
@@ -296,6 +297,48 @@ def test_wrap_queries_in_bool_clauses_if_more_than_one_with_one_query_generates_
     }
 
     assert generated_bool_clause == expected_bool_clause
+
+
+def test_wrap_queries_in_dis_max_clause_if_more_than_one_with_two_queries():
+    queries = [
+        {'match': {'title': 'collider'}},
+        {'match': {'subject': 'hep'}},
+    ]
+
+    generated_dis_max_clause = wrap_queries_in_dis_max_clause_if_more_than_one(queries)
+
+    expected_dis_max_clause = {
+        'dis_max': {
+            'queries': [
+                {'match': {'title': 'collider'}},
+                {'match': {'subject': 'hep'}},
+            ]
+        }
+    }
+
+    assert generated_dis_max_clause == expected_dis_max_clause
+
+
+def test_wrap_queries_in_dis_max_clause_if_more_than_one_with_one_query_returns_the_query_itself():
+    queries = [
+        {'match': {'title': 'collider'}},
+    ]
+
+    generated_dis_max_clause = wrap_queries_in_dis_max_clause_if_more_than_one(queries)
+
+    expected_dis_max_clause = {'match': {'title': 'collider'}}
+
+    assert generated_dis_max_clause == expected_dis_max_clause
+
+
+def test_wrap_queries_in_dis_max_clause_if_more_than_one_with_no_query_returns_empty_dict():
+    queries = []
+
+    generated_dis_max_clause = wrap_queries_in_dis_max_clause_if_more_than_one(queries)
+
+    expected_dis_max_clause = {}
+
+    assert generated_dis_max_clause == expected_dis_max_clause
 
 
 def test_generate_nested_query():


### PR DESCRIPTION
Handle unknown keyword searches (especially caused by texkey freetext searches or invenio syntax searches with keywords that are not inspire parser keywords). Instead of just querying the given field for the value found after the `:`, now we do a `dis_max` query that will contain the given field query + a query that searches `_all` for the entire value of the form `keyword:value`. This way, users can now look for texkeys using freetext, and still get results.

Signed-off-by: Iuliana Voinea <iulianavoinea96@gmail.com>