### PR TITLE
use simple_query_string for malformed queries

### DIFF
--- a/inspire_query_parser/visitors/elastic_search_visitor.py
+++ b/inspire_query_parser/visitors/elastic_search_visitor.py
@@ -472,8 +472,8 @@ class ElasticSearchVisitor(Visitor):
             query_str = ' '.join([word.strip(':') for word in data.children])
 
         return {
-            'query_string': {
-                'default_field': '_all',
+            'simple_query_string': {
+                'fields': ['_all'],
                 'query': query_str
             }
         }

--- a/tests/test_elastic_search_visitor.py
+++ b/tests/test_elastic_search_visitor.py
@@ -824,8 +824,8 @@ def test_elastic_search_visitor_with_malformed_query():
     query_str = 't: and t: electroweak'
     expected_es_query = \
         {
-            "query_string": {
-                "default_field": "_all",
+            "simple_query_string": {
+                "fields": ["_all"],
                 "query": "t and t electroweak"
             }
         }
@@ -852,8 +852,8 @@ def test_elastic_search_visitor_with_query_with_malformed_part_and_default_malfo
                         }
                     },
                     {
-                        "query_string": {
-                            "default_field": "_all",
+                        "simple_query_string": {
+                            "fields": ["_all"],
                             "query": "and author"
                         }
                     }
@@ -885,8 +885,8 @@ def test_elastic_search_visitor_with_query_with_malformed_part_and_default_malfo
                 ],
                 "should": [
                     {
-                        "query_string": {
-                            "default_field": "_all",
+                        "simple_query_string": {
+                            "fields": ["_all"],
                             "query": "and author"
                         }
                     }


### PR DESCRIPTION
So that elastic search won't throw an error.