### PR TITLE
Fix PDG search

### DIFF
--- a/inspire_query_parser/config.py
+++ b/inspire_query_parser/config.py
@@ -146,12 +146,6 @@ INSPIRE_PARSER_KEYWORDS = {
     # SPIRES identifiers
     'irn': 'irn',
 
-    # Job related
-    'position': 'title',
-    'region': 'region',
-    'continent': 'region',
-    'rank': 'rank',
-
     # Journal related
     'coden': 'journal',
     'journal': 'journal',

--- a/inspire_query_parser/stateful_pypeg_parser.py
+++ b/inspire_query_parser/stateful_pypeg_parser.py
@@ -45,4 +45,3 @@ class StatefulParser(Parser):
         super(StatefulParser, self).__init__()
         self._parsing_parenthesized_terminal = False
         self._parsing_parenthesized_simple_values_expression = False
-        self._parsing_texkey_expression = False

--- a/inspire_query_parser/utils/visitor_utils.py
+++ b/inspire_query_parser/utils/visitor_utils.py
@@ -461,6 +461,8 @@ def wrap_queries_in_bool_clauses_if_more_than_one(queries,
     if not queries:
         return {}
 
+    queries = [q for q in queries if q]
+
     if len(queries) == 1 and not preserve_bool_semantics_if_one_clause:
         return queries[0]
 

--- a/inspire_query_parser/visitors/elastic_search_visitor.py
+++ b/inspire_query_parser/visitors/elastic_search_visitor.py
@@ -102,6 +102,9 @@ class ElasticSearchVisitor(Visitor):
             'publication_info.year',
             'thesis_info.date',
         ],
+        'date-added': '_created',
+        'date-earliest': 'earliest_date',
+        'date-updated': '_updated',
         'doi': 'dois.value.raw',
         'eprint': 'arxiv_eprints.value.raw',
         'exact-author': 'authors.full_name_unicode_normalized',
@@ -109,6 +112,7 @@ class ElasticSearchVisitor(Visitor):
         'journal': [
             JOURNAL_FIELDS_MAPPING.values()
         ],
+        'keyword': 'keywords.value',
         'refersto': 'references.record.$ref',
         'reportnumber': 'report_numbers.value.fuzzy',
         'subject': 'facet_inspire_categories',

--- a/inspire_query_parser/visitors/elastic_search_visitor.py
+++ b/inspire_query_parser/visitors/elastic_search_visitor.py
@@ -837,25 +837,25 @@ class ElasticSearchVisitor(Visitor):
         )
 
         if self.KEYWORD_TO_ES_FIELDNAME['date'] == fieldnames:
-            term_queries = []
+            exact_match_queries = []
             for field in fieldnames:
                 term_query =  \
                     {'term': {field: _truncate_date_value_according_on_date_field(field, node.value).dumps()}}
 
-                term_queries.append(
+                exact_match_queries.append(
                     generate_nested_query(self.DATE_NESTED_QUERY_PATH, term_query)
                     if field in self.DATE_NESTED_FIELDS
                     else term_query
                 )
         elif self.KEYWORD_TO_ES_FIELDNAME['author'] in fieldnames:
-            term_queries = [
+            exact_match_queries = [
                 generate_nested_query(self.AUTHORS_NESTED_QUERY_PATH, {'term': {field: node.value}})
                 for field in (bai_fieldnames or fieldnames)
             ]
         else:
-            term_queries = [{'term': {field: node.value}} for field in (bai_fieldnames or fieldnames)]
+            exact_match_queries = [{'match_phrase': {field: node.value}} for field in (bai_fieldnames or fieldnames)]
 
-        return wrap_queries_in_bool_clauses_if_more_than_one(term_queries, use_must_clause=False)
+        return wrap_queries_in_bool_clauses_if_more_than_one(exact_match_queries, use_must_clause=False)
 
     def visit_partial_match_value(self, node, fieldnames=None):
         """Generates a query which looks for a substring of the node's value in the given fieldname."""

--- a/inspire_query_parser/visitors/elastic_search_visitor.py
+++ b/inspire_query_parser/visitors/elastic_search_visitor.py
@@ -188,17 +188,17 @@ class ElasticSearchVisitor(Visitor):
 
         normalized_author_name = normalize_name(node_value).strip('.')
 
-        if ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['author'] and \
-                ElasticSearchVisitor.BAI_REGEX.match(node_value):
-            return [ElasticSearchVisitor.AUTHORS_BAI_FIELD + '.' + bai_field_variation]
+        if self.KEYWORD_TO_ES_FIELDNAME['author'] and \
+                self.BAI_REGEX.match(node_value):
+            return [self.AUTHORS_BAI_FIELD + '.' + bai_field_variation]
 
         elif not whitespace.search(normalized_author_name) and \
                 query_bai_field_if_dots_in_name and \
-                ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['author'] and \
+                self.KEYWORD_TO_ES_FIELDNAME['author'] and \
                 '.' in normalized_author_name:
             # Case of partial BAI, e.g. ``J.Smith``.
-            return [ElasticSearchVisitor.AUTHORS_BAI_FIELD + '.' + bai_field_variation] + \
-                   force_list(ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['author'])
+            return [self.AUTHORS_BAI_FIELD + '.' + bai_field_variation] + \
+                   force_list(self.KEYWORD_TO_ES_FIELDNAME['author'])
 
         else:
             return None
@@ -227,7 +227,7 @@ class ElasticSearchVisitor(Visitor):
         def _match_query_with_analyzer(field, value):
             return {
                 "match": {
-                    ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME[field]: {
+                    self.KEYWORD_TO_ES_FIELDNAME[field]: {
                         "query": value,
                         "analyzer": "names_initials_analyzer"
                     }
@@ -237,7 +237,7 @@ class ElasticSearchVisitor(Visitor):
         def _match_query_without_analyzer(field, value):
             return {
                 "match": {
-                    ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME[field]: {
+                    self.KEYWORD_TO_ES_FIELDNAME[field]: {
                         "query": value
                     }
                 }
@@ -246,7 +246,7 @@ class ElasticSearchVisitor(Visitor):
         def _match_query_with_and_operator(field, value):
             return {
                 'match': {
-                    ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME[field]: {
+                    self.KEYWORD_TO_ES_FIELDNAME[field]: {
                         'query': value,
                         'operator': 'AND'
                     }
@@ -256,7 +256,7 @@ class ElasticSearchVisitor(Visitor):
         def _match_phrase_prefix_query(field, value):
             return {
                 "match_phrase_prefix": {
-                    ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME[field]: {
+                    self.KEYWORD_TO_ES_FIELDNAME[field]: {
                         "query": value,
                         "analyzer": "names_analyzer"
                     }
@@ -268,7 +268,7 @@ class ElasticSearchVisitor(Visitor):
             # in our case we consider it as a lastname
             last_name = parsed_name.first
             query = _match_query_with_and_operator("author_last_name", last_name)
-            return generate_nested_query(ElasticSearchVisitor.AUTHORS_NESTED_QUERY_PATH, query)
+            return generate_nested_query(self.AUTHORS_NESTED_QUERY_PATH, query)
 
         bool_query_build = []
         bool_query_build.append(
@@ -301,33 +301,33 @@ class ElasticSearchVisitor(Visitor):
         query = wrap_queries_in_bool_clauses_if_more_than_one(
             bool_query_build, use_must_clause=True
         )
-        return generate_nested_query(ElasticSearchVisitor.AUTHORS_NESTED_QUERY_PATH, query)
+        return generate_nested_query(self.AUTHORS_NESTED_QUERY_PATH, query)
 
     def _generate_exact_author_query(self, author_name_or_bai):
         """Generates a term query handling authors and BAIs.
 
         Notes:
             If given value is a BAI, search for the provided value in the raw field variation of
-            `ElasticSearchVisitor.AUTHORS_BAI_FIELD`.
+            `self.AUTHORS_BAI_FIELD`.
             Otherwise, the value will be procesed in the same way as the indexed value (i.e. lowercased and normalized
             (inspire_utils.normalize_name and then NFKC normalization).
             E.g. Searching for 'Smith, J.' is the same as searching for: 'Smith, J', 'smith, j.', 'smith j', 'j smith',
             'j. smith', 'J Smith', 'J. Smith'.
         """
-        if ElasticSearchVisitor.BAI_REGEX.match(author_name_or_bai):
+        if self.BAI_REGEX.match(author_name_or_bai):
             bai = author_name_or_bai.lower()
             query = self._generate_term_query(
-                '.'.join((ElasticSearchVisitor.AUTHORS_BAI_FIELD, FieldVariations.search)),
+                '.'.join((self.AUTHORS_BAI_FIELD, FieldVariations.search)),
                 bai
             )
         else:
             author_name = normalize('NFKC', normalize_name(author_name_or_bai)).lower()
             query = self._generate_term_query(
-                ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['exact-author'],
+                self.KEYWORD_TO_ES_FIELDNAME['exact-author'],
                 author_name
             )
 
-        return generate_nested_query(ElasticSearchVisitor.AUTHORS_NESTED_QUERY_PATH, query)
+        return generate_nested_query(self.AUTHORS_NESTED_QUERY_PATH, query)
 
     def _generate_date_with_wildcard_query(self, date_value):
         """Helper for generating a date keyword query containing a wildcard.
@@ -351,8 +351,7 @@ class ElasticSearchVisitor(Visitor):
             # Drop date query with wildcard not as suffix, e.g. 2000-1*-31
             return {}
 
-    @staticmethod
-    def _generate_queries_for_title_symbols(title_field, query_value):
+    def _generate_queries_for_title_symbols(self, title_field, query_value):
         """Generate queries for any symbols in the title against the whitespace tokenized field of titles.
 
         Returns:
@@ -369,7 +368,7 @@ class ElasticSearchVisitor(Visitor):
         for value in values_tokenized_by_whitespace:
             # Heuristic: If there's a symbol-indicating-character in the value, it signifies terms that should be
             # queried against the whitespace-tokenized title.
-            if any(character in value for character in ElasticSearchVisitor.TITLE_SYMBOL_INDICATING_CHARACTER):
+            if any(character in value for character in self.TITLE_SYMBOL_INDICATING_CHARACTER):
                 symbol_queries.append(
                     generate_match_query(
                         '.'.join([title_field, FieldVariations.search]),
@@ -381,10 +380,10 @@ class ElasticSearchVisitor(Visitor):
         return wrap_queries_in_bool_clauses_if_more_than_one(symbol_queries, use_must_clause=True)
 
     def _generate_title_queries(self, value):
-        title_field = ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['title']
+        title_field = self.KEYWORD_TO_ES_FIELDNAME['title']
         q = generate_match_query(title_field, value, with_operator_and=True)
 
-        symbol_queries = ElasticSearchVisitor._generate_queries_for_title_symbols(title_field, value)
+        symbol_queries = self._generate_queries_for_title_symbols(title_field, value)
         return wrap_queries_in_bool_clauses_if_more_than_one(
             [element for element in (q, symbol_queries) if element],
             use_must_clause=True
@@ -480,7 +479,7 @@ class ElasticSearchVisitor(Visitor):
             Additionally, in the aforementioned case, if a malformed date has been given, then the the method will
             return an empty dictionary.
         """
-        if ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['date'] == fieldnames:
+        if self.KEYWORD_TO_ES_FIELDNAME['date'] == fieldnames:
             range_queries = []
             for fieldname in fieldnames:
                 updated_operator_value_pairs = \
@@ -496,8 +495,8 @@ class ElasticSearchVisitor(Visitor):
                     }
 
                     range_queries.append(
-                        generate_nested_query(ElasticSearchVisitor.DATE_NESTED_QUERY_PATH, range_query)
-                        if fieldname in ElasticSearchVisitor.DATE_NESTED_FIELDS
+                        generate_nested_query(self.DATE_NESTED_QUERY_PATH, range_query)
+                        if fieldname in self.DATE_NESTED_FIELDS
                         else range_query
                     )
         else:
@@ -532,8 +531,7 @@ class ElasticSearchVisitor(Visitor):
             }
         }
 
-    @staticmethod
-    def _preprocess_journal_query_value(third_journal_field, old_publication_info_values):
+    def _preprocess_journal_query_value(self, third_journal_field, old_publication_info_values):
         """Transforms the given journal query value (old publication info) to the new one.
 
         Args:
@@ -546,8 +544,8 @@ class ElasticSearchVisitor(Visitor):
         """
         # Prepare old publication info for :meth:`inspire_schemas.utils.convert_old_publication_info_to_new`.
         publication_info_keys = [
-            ElasticSearchVisitor.JOURNAL_TITLE,
-            ElasticSearchVisitor.JOURNAL_VOLUME,
+            self.JOURNAL_TITLE,
+            self.JOURNAL_VOLUME,
             third_journal_field,
         ]
         values_list = [
@@ -586,23 +584,23 @@ class ElasticSearchVisitor(Visitor):
             be assigned to corresponding fields.
         """
         # Abstract away which is the third field, we care only for its existence.
-        third_journal_field = ElasticSearchVisitor.JOURNAL_PAGE_START
+        third_journal_field = self.JOURNAL_PAGE_START
 
-        new_publication_info = ElasticSearchVisitor._preprocess_journal_query_value(third_journal_field, value)
+        new_publication_info = self._preprocess_journal_query_value(third_journal_field, value)
 
         # We always expect a journal title, otherwise query would be considered malformed, and thus this method would
         # not have been called.
         queries_for_each_field = [
-            generate_match_query(ElasticSearchVisitor.JOURNAL_FIELDS_MAPPING[ElasticSearchVisitor.JOURNAL_TITLE],
-                                 new_publication_info[ElasticSearchVisitor.JOURNAL_TITLE],
+            generate_match_query(self.JOURNAL_FIELDS_MAPPING[self.JOURNAL_TITLE],
+                                 new_publication_info[self.JOURNAL_TITLE],
                                  with_operator_and=False)
         ]
 
-        if ElasticSearchVisitor.JOURNAL_VOLUME in new_publication_info:
+        if self.JOURNAL_VOLUME in new_publication_info:
             queries_for_each_field.append(
                 generate_match_query(
-                    ElasticSearchVisitor.JOURNAL_FIELDS_MAPPING[ElasticSearchVisitor.JOURNAL_VOLUME],
-                    new_publication_info[ElasticSearchVisitor.JOURNAL_VOLUME],
+                    self.JOURNAL_FIELDS_MAPPING[self.JOURNAL_VOLUME],
+                    new_publication_info[self.JOURNAL_VOLUME],
                     with_operator_and=False
                 )
             )
@@ -611,12 +609,12 @@ class ElasticSearchVisitor(Visitor):
             artid_or_page_start = new_publication_info[third_journal_field]
             match_queries = [
                 generate_match_query(
-                    ElasticSearchVisitor.JOURNAL_FIELDS_MAPPING[third_field],
+                    self.JOURNAL_FIELDS_MAPPING[third_field],
                     artid_or_page_start,
                     with_operator_and=False
                 )
                 for third_field
-                in (ElasticSearchVisitor.JOURNAL_PAGE_START, ElasticSearchVisitor.JOURNAL_ART_ID)
+                in (self.JOURNAL_PAGE_START, self.JOURNAL_ART_ID)
             ]
 
             queries_for_each_field.append(
@@ -624,7 +622,7 @@ class ElasticSearchVisitor(Visitor):
             )
 
         return generate_nested_query(
-            ElasticSearchVisitor.JOURNAL_FIELDS_PREFIX,
+            self.JOURNAL_FIELDS_PREFIX,
             wrap_queries_in_bool_clauses_if_more_than_one(queries_for_each_field, use_must_clause=True)
         )
     # ################
@@ -636,7 +634,7 @@ class ElasticSearchVisitor(Visitor):
         return generate_match_query('_all', node.op.value, with_operator_and=True)
 
     def visit_malformed_query(self, node):
-        return ElasticSearchVisitor._generate_malformed_query(node)
+        return self._generate_malformed_query(node)
 
     def visit_query_with_malformed_part(self, node):
         query = {
@@ -695,7 +693,7 @@ class ElasticSearchVisitor(Visitor):
             if hasattr(right, 'left') and hasattr(right, 'right') and right.left.value == 'control_number':
                 recid = right.right.value
                 citing_records_query = generate_match_query(
-                    ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['refersto'],
+                    self.KEYWORD_TO_ES_FIELDNAME['refersto'],
                     recid,
                     with_operator_and=False
                 )
@@ -705,7 +703,7 @@ class ElasticSearchVisitor(Visitor):
                     with_operator_and=False
                 )
                 superseded_records_query = generate_match_query(
-                    ElasticSearchVisitor.RECORD_RELATION_FIELD,
+                    self.RECORD_RELATION_FIELD,
                     'successor',
                     with_operator_and=False
                 )
@@ -724,14 +722,14 @@ class ElasticSearchVisitor(Visitor):
 
     def visit_keyword(self, node):
         # If no keyword is found, return the original node value (case of an unknown keyword).
-        return ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME.get(node.value, node.value)
+        return self.KEYWORD_TO_ES_FIELDNAME.get(node.value, node.value)
 
     def visit_value(self, node, fieldnames=None):
         if not fieldnames:
             fieldnames = '_all'
 
         if node.contains_wildcard:
-            if ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['date'] == fieldnames:
+            if self.KEYWORD_TO_ES_FIELDNAME['date'] == fieldnames:
                 return self._generate_date_with_wildcard_query(node.value)
 
             bai_fieldnames = self._generate_fieldnames_if_bai_query(
@@ -746,17 +744,17 @@ class ElasticSearchVisitor(Visitor):
                 analyze_wildcard=True
             )
 
-            if ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['author'] == fieldnames:
-                return generate_nested_query(ElasticSearchVisitor.AUTHORS_NESTED_QUERY_PATH, query)
+            if self.KEYWORD_TO_ES_FIELDNAME['author'] == fieldnames:
+                return generate_nested_query(self.AUTHORS_NESTED_QUERY_PATH, query)
             return query
         else:
             if isinstance(fieldnames, list):
-                if ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['date'] == fieldnames:
+                if self.KEYWORD_TO_ES_FIELDNAME['date'] == fieldnames:
                     # Date queries with simple values are transformed into range queries, among the given and the exact
                     # next date, according to the granularity of the given date.
                     return self._generate_range_queries(force_list(fieldnames), {ES_RANGE_EQ_OPERATOR: node.value})
 
-                if ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['journal'] == fieldnames:
+                if self.KEYWORD_TO_ES_FIELDNAME['journal'] == fieldnames:
                     return self._generate_journal_nested_queries(node.value)
 
                 return {
@@ -766,7 +764,7 @@ class ElasticSearchVisitor(Visitor):
                     }
                 }
             else:
-                if ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['author'] == fieldnames:
+                if self.KEYWORD_TO_ES_FIELDNAME['author'] == fieldnames:
                     bai_fieldnames = self._generate_fieldnames_if_bai_query(
                         node.value,
                         bai_field_variation=FieldVariations.search,
@@ -775,7 +773,7 @@ class ElasticSearchVisitor(Visitor):
                     if bai_fieldnames:
                         if len(bai_fieldnames) == 1:
                             query = {"match": {bai_fieldnames[0]: node.value}}
-                            return generate_nested_query(ElasticSearchVisitor.AUTHORS_NESTED_QUERY_PATH, query)
+                            return generate_nested_query(self.AUTHORS_NESTED_QUERY_PATH, query)
                         else:
                             # Not an exact BAI pattern match, but node's value looks like BAI (no spaces and dots),
                             # e.g. `S.Mele`. In this case generate a partial match query.
@@ -783,33 +781,33 @@ class ElasticSearchVisitor(Visitor):
 
                     return self._generate_author_query(node.value)
 
-                elif ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['exact-author'] == fieldnames:
+                elif self.KEYWORD_TO_ES_FIELDNAME['exact-author'] == fieldnames:
                     return self._generate_exact_author_query(node.value)
 
-                elif ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['irn'] == fieldnames:
+                elif self.KEYWORD_TO_ES_FIELDNAME['irn'] == fieldnames:
                     return {'term': {fieldnames: ''.join(('SPIRES-', node.value))}}
 
-                elif ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['title'] == fieldnames:
+                elif self.KEYWORD_TO_ES_FIELDNAME['title'] == fieldnames:
                     return self._generate_title_queries(node.value)
 
-                elif ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['type-code'] == fieldnames:
+                elif self.KEYWORD_TO_ES_FIELDNAME['type-code'] == fieldnames:
                     return self._generate_type_code_query(node.value)
 
-                elif ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['affiliation'] == fieldnames:
+                elif self.KEYWORD_TO_ES_FIELDNAME['affiliation'] == fieldnames:
                     query = generate_match_query(
-                        ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['affiliation'],
+                        self.KEYWORD_TO_ES_FIELDNAME['affiliation'],
                         node.value,
                         with_operator_and=True
                     )
-                    return generate_nested_query(ElasticSearchVisitor.AUTHORS_NESTED_QUERY_PATH, query)
+                    return generate_nested_query(self.AUTHORS_NESTED_QUERY_PATH, query)
 
-                elif fieldnames not in ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME.values():
+                elif fieldnames not in self.KEYWORD_TO_ES_FIELDNAME.values():
                     colon_value = ':'.join([fieldnames, node.value])
                     given_field_query = generate_match_query(fieldnames, node.value, with_operator_and=True)
                     texkey_query = self._generate_term_query('texkeys.raw', colon_value, boost=2.0)
                     _all_field_query = generate_match_query('_all', colon_value, with_operator_and=True)
                     query = wrap_queries_in_bool_clauses_if_more_than_one([given_field_query, texkey_query, _all_field_query], use_must_clause=False)
-                    return wrap_query_in_nested_if_field_is_nested(query, fieldnames, ElasticSearchVisitor.NESTED_FIELDS)
+                    return wrap_query_in_nested_if_field_is_nested(query, fieldnames, self.NESTED_FIELDS)
 
                 return generate_match_query(fieldnames, node.value, with_operator_and=True)
 
@@ -820,13 +818,13 @@ class ElasticSearchVisitor(Visitor):
         else:
             fieldnames = force_list(fieldnames)
 
-        if ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['exact-author'] == fieldnames[0]:
+        if self.KEYWORD_TO_ES_FIELDNAME['exact-author'] == fieldnames[0]:
             return self._generate_exact_author_query(node.value)
 
-        elif ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['type-code'] == fieldnames[0]:
+        elif self.KEYWORD_TO_ES_FIELDNAME['type-code'] == fieldnames[0]:
             return self._generate_type_code_query(node.value)
 
-        elif ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['journal'] == fieldnames:
+        elif self.KEYWORD_TO_ES_FIELDNAME['journal'] == fieldnames:
             return self._generate_journal_nested_queries(node.value)
 
         bai_fieldnames = self._generate_fieldnames_if_bai_query(
@@ -835,20 +833,20 @@ class ElasticSearchVisitor(Visitor):
             query_bai_field_if_dots_in_name=False
         )
 
-        if ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['date'] == fieldnames:
+        if self.KEYWORD_TO_ES_FIELDNAME['date'] == fieldnames:
             term_queries = []
             for field in fieldnames:
                 term_query =  \
                     {'term': {field: _truncate_date_value_according_on_date_field(field, node.value).dumps()}}
 
                 term_queries.append(
-                    generate_nested_query(ElasticSearchVisitor.DATE_NESTED_QUERY_PATH, term_query)
-                    if field in ElasticSearchVisitor.DATE_NESTED_FIELDS
+                    generate_nested_query(self.DATE_NESTED_QUERY_PATH, term_query)
+                    if field in self.DATE_NESTED_FIELDS
                     else term_query
                 )
-        elif ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['author'] in fieldnames:
+        elif self.KEYWORD_TO_ES_FIELDNAME['author'] in fieldnames:
             term_queries = [
-                generate_nested_query(ElasticSearchVisitor.AUTHORS_NESTED_QUERY_PATH, {'term': {field: node.value}})
+                generate_nested_query(self.AUTHORS_NESTED_QUERY_PATH, {'term': {field: node.value}})
                 for field in (bai_fieldnames or fieldnames)
             ]
         else:
@@ -858,7 +856,7 @@ class ElasticSearchVisitor(Visitor):
 
     def visit_partial_match_value(self, node, fieldnames=None):
         """Generates a query which looks for a substring of the node's value in the given fieldname."""
-        if ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['date'] == fieldnames:
+        if self.KEYWORD_TO_ES_FIELDNAME['date'] == fieldnames:
             # Date queries with partial values are transformed into range queries, among the given and the exact
             # next date, according to the granularity of the given date.
             if node.contains_wildcard:
@@ -866,13 +864,13 @@ class ElasticSearchVisitor(Visitor):
 
             return self._generate_range_queries(force_list(fieldnames), {ES_RANGE_EQ_OPERATOR: node.value})
 
-        if ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['exact-author'] == fieldnames:
+        if self.KEYWORD_TO_ES_FIELDNAME['exact-author'] == fieldnames:
             return self._generate_exact_author_query(node.value)
 
-        elif ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['type-code'] == fieldnames:
+        elif self.KEYWORD_TO_ES_FIELDNAME['type-code'] == fieldnames:
             return self._generate_type_code_query(node.value)
 
-        elif ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['journal'] == fieldnames:
+        elif self.KEYWORD_TO_ES_FIELDNAME['journal'] == fieldnames:
             return self._generate_journal_nested_queries(node.value)
 
         # Add wildcard token as prefix and suffix.
@@ -890,9 +888,9 @@ class ElasticSearchVisitor(Visitor):
         query = self._generate_query_string_query(value,
                                                   fieldnames=bai_fieldnames or fieldnames,
                                                   analyze_wildcard=True)
-        if (bai_fieldnames and ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['author'] in bai_fieldnames) \
-                or (fieldnames and ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['author'] in fieldnames):
-            return generate_nested_query(ElasticSearchVisitor.AUTHORS_NESTED_QUERY_PATH, query)
+        if (bai_fieldnames and self.KEYWORD_TO_ES_FIELDNAME['author'] in bai_fieldnames) \
+                or (fieldnames and self.KEYWORD_TO_ES_FIELDNAME['author'] in fieldnames):
+            return generate_nested_query(self.AUTHORS_NESTED_QUERY_PATH, query)
 
         return query
 
@@ -903,7 +901,7 @@ class ElasticSearchVisitor(Visitor):
             }
         }
 
-        if ElasticSearchVisitor.KEYWORD_TO_ES_FIELDNAME['author'] == fieldname:
-            return generate_nested_query(ElasticSearchVisitor.AUTHORS_NESTED_QUERY_PATH, query)
+        if self.KEYWORD_TO_ES_FIELDNAME['author'] == fieldname:
+            return generate_nested_query(self.AUTHORS_NESTED_QUERY_PATH, query)
 
         return query

--- a/inspire_query_parser/visitors/elastic_search_visitor.py
+++ b/inspire_query_parser/visitors/elastic_search_visitor.py
@@ -155,6 +155,7 @@ class ElasticSearchVisitor(Visitor):
     AUTHORS_NAME_VARIATIONS_FIELD = 'authors.name_variations'
     AUTHORS_BAI_FIELD = 'authors.ids.value'
     BAI_REGEX = re.compile(r'^((\w|-|\')+\.)+\d+$', re.UNICODE | re.IGNORECASE)
+    TEXKEY_REGEX = re.compile(r'^\w+:\d{4}\w{2,3}', re.UNICODE)
     AUTHORS_NESTED_QUERY_PATH = 'authors'
     DATE_NESTED_FIELDS = [
         'publication_info.year',
@@ -804,7 +805,9 @@ class ElasticSearchVisitor(Visitor):
                 elif fieldnames not in self.KEYWORD_TO_ES_FIELDNAME.values():
                     colon_value = ':'.join([fieldnames, node.value])
                     given_field_query = generate_match_query(fieldnames, node.value, with_operator_and=True)
-                    texkey_query = self._generate_term_query('texkeys.raw', colon_value, boost=2.0)
+                    texkey_query = ''
+                    if self.TEXKEY_REGEX.match(colon_value):
+                        texkey_query = self._generate_term_query('texkeys.raw', colon_value, boost=2.0)
                     _all_field_query = generate_match_query('_all', colon_value, with_operator_and=True)
                     query = wrap_queries_in_bool_clauses_if_more_than_one([given_field_query, texkey_query, _all_field_query], use_must_clause=False)
                     return wrap_query_in_nested_if_field_is_nested(query, fieldnames, self.NESTED_FIELDS)

--- a/tests/test_elastic_search_visitor.py
+++ b/tests/test_elastic_search_visitor.py
@@ -496,14 +496,6 @@ def test_elastic_search_visitor_unknown_keyword_simple_value():
                     }
                 },
                 {
-                    "term": {
-                        "texkeys.raw": {
-                            "value": "unknown_keyword:bar",
-                            "boost": 2.0
-                        }
-                    }
-                },
-                {
                     "match": {
                         "_all": {
                             "query": "unknown_keyword:bar",
@@ -529,14 +521,6 @@ def test_elastic_search_visitor_dotted_keyword_simple_value():
                         "dotted.keyword": {
                             "query": "bar",
                             "operator": "and",
-                        }
-                    }
-                },
-                {
-                    "term": {
-                        "texkeys.raw": {
-                            "value": "dotted.keyword:bar",
-                            "boost": 2.0
                         }
                     }
                 },
@@ -2168,14 +2152,6 @@ def test_nested_publication_info_fields_query():
                                 }
                             },
                             {
-                                "term": {
-                                    "texkeys.raw": {
-                                        "boost": 2.0,
-                                        "value": "publication_info.journal_title:JHEP"
-                                    }
-                                }
-                            },
-                            {
                                 "match": {
                                     "_all": {
                                         "operator": "and",
@@ -2251,7 +2227,7 @@ def test_affiliation_query():
         assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_type_code_legacy_comaptible_case_insensitive():
+def test_elastic_search_visitor_type_code_legacy_compatible_case_insensitive():
     query_str = "collection ConferencePaper"
     expected_es_query = \
         {
@@ -2266,7 +2242,7 @@ def test_elastic_search_visitor_type_code_legacy_comaptible_case_insensitive():
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_type_code_legacy_comaptible_book():
+def test_elastic_search_visitor_type_code_legacy_compatible_book():
     query_str = "collection book"
     expected_es_query = \
         {
@@ -2281,7 +2257,7 @@ def test_elastic_search_visitor_type_code_legacy_comaptible_book():
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_type_code_legacy_comaptible_conference_paper():
+def test_elastic_search_visitor_type_code_legacy_compatible_conference_paper():
     query_str = "collection conferencepaper"
     expected_es_query = \
         {
@@ -2296,7 +2272,7 @@ def test_elastic_search_visitor_type_code_legacy_comaptible_conference_paper():
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_type_code_legacy_comaptible_citeable():
+def test_elastic_search_visitor_type_code_legacy_compatible_citeable():
     query_str = "collection citeable"
     expected_es_query = \
         {
@@ -2309,7 +2285,7 @@ def test_elastic_search_visitor_type_code_legacy_comaptible_citeable():
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_type_code_legacy_comaptible_introductory():
+def test_elastic_search_visitor_type_code_legacy_compatible_introductory():
     query_str = "collection introductory"
     expected_es_query = \
         {
@@ -2324,7 +2300,7 @@ def test_elastic_search_visitor_type_code_legacy_comaptible_introductory():
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_type_code_legacy_comaptible_lectures():
+def test_elastic_search_visitor_type_code_legacy_compatible_lectures():
     query_str = "collection lectures"
     expected_es_query = \
         {
@@ -2339,7 +2315,7 @@ def test_elastic_search_visitor_type_code_legacy_comaptible_lectures():
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_type_code_legacy_comaptible_published():
+def test_elastic_search_visitor_type_code_legacy_compatible_published():
     query_str = "collection published"
     expected_es_query = \
         {
@@ -2352,7 +2328,7 @@ def test_elastic_search_visitor_type_code_legacy_comaptible_published():
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_type_code_legacy_comaptible_review():
+def test_elastic_search_visitor_type_code_legacy_compatible_review():
     query_str = "collection review"
     expected_es_query = \
         {
@@ -2367,7 +2343,7 @@ def test_elastic_search_visitor_type_code_legacy_comaptible_review():
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_type_code_legacy_comaptible_thesis():
+def test_elastic_search_visitor_type_code_legacy_compatible_thesis():
     query_str = "collection thesis"
     expected_es_query = \
         {
@@ -2382,7 +2358,7 @@ def test_elastic_search_visitor_type_code_legacy_comaptible_thesis():
     assert generated_es_query == expected_es_query
 
 
-def test_elastic_search_visitor_type_code_legacy_comaptible_proceedings():
+def test_elastic_search_visitor_type_code_legacy_compatible_proceedings():
     query_str = "collection proceedings"
     expected_es_query = \
         {

--- a/tests/test_elastic_search_visitor.py
+++ b/tests/test_elastic_search_visitor.py
@@ -511,6 +511,43 @@ def test_elastic_search_visitor_unknown_keyword_simple_value():
     assert generated_es_query == expected_es_query
 
 
+def test_elastic_search_visitor_unknown_keyword_simple_value_maybe_texkey():
+    query_str = 'smith:2009xj'
+    expected_es_query = {
+        "bool": {
+            "should": [
+                {
+                    "match": {
+                        "smith": {
+                            "query": "2009xj",
+                            "operator": "and",
+                        }
+                    }
+                },
+                {
+                    "term": {
+                        "texkeys.raw": {
+                            "value": "smith:2009xj",
+                            "boost": 2.0,
+                        }
+                    }
+                },
+                {
+                    "match": {
+                        "_all": {
+                            "query": "smith:2009xj",
+                            "operator": "and",
+                        }
+                    }
+                }
+            ]
+        }
+    }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
 def test_elastic_search_visitor_dotted_keyword_simple_value():
     query_str = 'dotted.keyword:bar'
     expected_es_query = {
@@ -626,7 +663,7 @@ def test_elastic_search_visitor_keyword_query_and_exact_value_query():
                         }
                     },
                     {
-                        "term": {
+                        "match_phrase": {
                             "_all": "skands",
                         }
                     }
@@ -2368,6 +2405,19 @@ def test_elastic_search_visitor_type_code_legacy_compatible_proceedings():
                 }
             }
         }
+
+    generated_es_query = _parse_query(query_str)
+    assert generated_es_query == expected_es_query
+
+
+def test_elastic_search_visitor_PDG_keyword():
+    query_str = 'keyword "S044:DESIG=1"'
+    expected_es_query = {
+        "match_phrase": {
+            "keywords.value": "S044:DESIG=1",
+
+        }
+    }
 
     generated_es_query = _parse_query(query_str)
     assert generated_es_query == expected_es_query

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -153,7 +153,12 @@ def test_simple_value_unit_accepted_tokens(query_str, unrecognized_text, result)
             'query_str': '(and)',
             'unrecognized_text': '',
             'result': SimpleValue('(and)')
-        }
+        },
+        'Plaintext with colons in the first word': {
+            'query_str': 'foo:bar baz:quux',
+            'unrecognized_text': 'baz:quux',
+            'result': SimpleValue('foo:bar')
+        },
     }
 )
 def test_simple_value_accepted_tokens(query_str, unrecognized_text, result):


### PR DESCRIPTION
Several changes to the query parser:
* Values with colons inside are now handled for all keywords. This was not handled previously due to the ambiguity in `key foo bar:baz`. Is it a search for `foo bar:baz` in `key` or a search for `foo` in `key` and `baz` in `bar`? To handle this, colons are allowed only in the first space-separated value. As a side-effect, this allowed to remove the special-casing for texkey searches.
* Exact matches are delimited by `"..."`. This was previously translated into a `term` query (for most fields), which is useless for `text` fields as the search query needs to match exactly the output of the analyzer. Now a `match_phrase` is used, which should work correctly.
* Search for creation, update and earliest dates are now handled correctly.
* Makes the searching for texkeys more strict. Previously anything containing a `:` would also search in the texkey field. Now the texkey search is only emitted if the term looks like a texkey.
* INSPIR-3309
* INSPIR-3310