### PR TITLE
authors: add AND on name_initials_analyzer of firstname

### DIFF
--- a/inspire_query_parser/visitors/elastic_search_visitor.py
+++ b/inspire_query_parser/visitors/elastic_search_visitor.py
@@ -225,11 +225,12 @@ class ElasticSearchVisitor(Visitor):
         """
         parsed_name = ParsedName(author_name)
 
-        def _match_query_with_analyzer(field, value):
+        def _match_query_with_analyzer_with_and_operator(field, value):
             return {
                 "match": {
                     self.KEYWORD_TO_ES_FIELDNAME[field]: {
                         "query": value,
+                        'operator': 'AND',
                         "analyzer": "names_initials_analyzer"
                     }
                 }
@@ -287,7 +288,7 @@ class ElasticSearchVisitor(Visitor):
             else:
                 name_query.extend([
                     _match_phrase_prefix_query("author_first_name", name),
-                    _match_query_with_analyzer("author_first_name", name)
+                    _match_query_with_analyzer_with_and_operator("author_first_name", name)
                 ])
             should_query.append(
                 wrap_queries_in_bool_clauses_if_more_than_one(

--- a/tests/test_elastic_search_visitor.py
+++ b/tests/test_elastic_search_visitor.py
@@ -1633,7 +1633,7 @@ def test_hack_to_split_initial_and_firstname_without_a_space():
                                     {
                                         "match": {
                                             "authors.first_name.initials": {
-                                                "query": "D",
+                                                "query": "D"
                                             }
                                         }
                                     },
@@ -1652,6 +1652,7 @@ def test_hack_to_split_initial_and_firstname_without_a_space():
                                                     "match": {
                                                         "authors.first_name": {
                                                             "analyzer": "names_initials_analyzer",
+                                                            "operator": "AND",
                                                             "query": "John",
                                                         }
                                                     }
@@ -1734,13 +1735,7 @@ def test_elastic_search_visitor_author_lastname_initial():
                                 }
                             }
                         },
-                        {
-                            "match": {
-                                "authors.first_name.initials": {
-                                    "query": "J",
-                                }
-                            }
-                        },
+                        {"match": {"authors.first_name.initials": {"query": "J"}}},
                     ]
                 }
             },
@@ -1783,6 +1778,7 @@ def test_elastic_search_visitor_author_lastname_firstname():
                                         "match": {
                                             "authors.first_name": {
                                                 "analyzer": "names_initials_analyzer",
+                                                "operator": "AND",
                                                 "query": "John",
                                             }
                                         }
@@ -1831,6 +1827,7 @@ def test_elastic_search_visitor_author_lastname_firstname_without_comma():
                                         "match": {
                                             "authors.first_name": {
                                                 "analyzer": "names_initials_analyzer",
+                                                "operator": "AND",
                                                 "query": "John",
                                             }
                                         }
@@ -1882,6 +1879,7 @@ def test_elastic_search_visitor_author_lastname_firstname_without_commas_and_ini
                                                     "match": {
                                                         "authors.first_name": {
                                                             "analyzer": "names_initials_analyzer",
+                                                            "operator": "AND",
                                                             "query": "John",
                                                         }
                                                     }
@@ -1892,7 +1890,7 @@ def test_elastic_search_visitor_author_lastname_firstname_without_commas_and_ini
                                     {
                                         "match": {
                                             "authors.first_name.initials": {
-                                                "query": "K.",
+                                                "query": "K."
                                             }
                                         }
                                     },
@@ -1944,6 +1942,7 @@ def test_elastic_search_visitor_author_lastname_firstname_with_commas_and_initia
                                                     "match": {
                                                         "authors.first_name": {
                                                             "analyzer": "names_initials_analyzer",
+                                                            "operator": "AND",
                                                             "query": "John",
                                                         }
                                                     }


### PR DESCRIPTION
This is will fix the problem when you search ``a Lian-Tao Foo``

will search ``Lian-Tao Foo`` in firstname **OR** (``L`` in first name **AND** ``T`` in firstname) to avoid having results from just ``L Foo`` and ``T Foo``